### PR TITLE
Implement opening_hours "days", other blocks improvements

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,24 +1,31 @@
 [[source]]
+
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
+
 [dev-packages]
+
 pytest = "*"
 lovely-pytest-docker = "*"
 freezegun = "*"
 ipython = "*"
 responses = "*"
 
+
 [packages]
+
 apistar = "==0.5.*"
 elasticsearch = ">=2.0.0,<3.0.0"
 requests = "==2.*"
-osm-humanized-opening-hours = "*"
 tzwhere = "*"
 babel = "*"
 pybreaker = "*"
+osm-humanized-opening-hours = "==0.6.2"
+lark-parser = "<0.6"
+
 
 [requires]
-python_version = "3.6"
 
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,20 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1875f6f292549094c1b323b1bf4a4f60fc194dae34b54d192921bf328adafa34"
-        },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "4.8.0-53-generic",
-            "platform_system": "Linux",
-            "platform_version": "#56~16.04.1-Ubuntu SMP Tue May 16 01:18:56 UTC 2017",
-            "python_full_version": "3.6.3",
-            "python_version": "3.6",
-            "sys_platform": "linux"
+            "sha256": "415f136026f9d083ddb8c0df9b96d51fdb741e47c92af2e6c4a75f103659edc0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,6 +20,7 @@
             "hashes": [
                 "sha256:9158cbdc0449751f0efbc98800546c1cd212f1ff6f8b2a11d2f9df4fcf943110"
             ],
+            "index": "pypi",
             "version": "==0.5.40"
         },
         "babel": {
@@ -40,19 +28,20 @@
                 "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
                 "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
             ],
+            "index": "pypi",
             "version": "==2.6.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0",
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
             "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
         },
@@ -68,6 +57,7 @@
                 "sha256:bb8f9a365ba6650d599428538c8aed42033264661d8f7d353da59d5892305f72",
                 "sha256:fead47ebfcaabd1c53dbfc21403eb99ac207eef76de8002fe11a1c8ec9589ce2"
             ],
+            "index": "pypi",
             "version": "==2.4.1"
         },
         "idna": {
@@ -88,6 +78,7 @@
             "hashes": [
                 "sha256:2074f2cda9303167f97da0157eefa6fdf9c0b8c7786d4a24e86c65319b34c0df"
             ],
+            "index": "pypi",
             "version": "==0.5.6"
         },
         "markupsafe": {
@@ -98,15 +89,17 @@
         },
         "osm-humanized-opening-hours": {
             "hashes": [
-                "sha256:327e1db0f87bb8242901b977236e6572dc75746547f6196f1bf4d442796dbe72",
-                "sha256:0bf6eac962fda54e73260d400ece72d84b857150f6bf6b839b514075b3641120"
+                "sha256:0bf6eac962fda54e73260d400ece72d84b857150f6bf6b839b514075b3641120",
+                "sha256:327e1db0f87bb8242901b977236e6572dc75746547f6196f1bf4d442796dbe72"
             ],
+            "index": "pypi",
             "version": "==0.6.2"
         },
         "pybreaker": {
             "hashes": [
                 "sha256:c034de4e8d0501bda05dcab21e08f43a4956cf59c1605c8b8d1504ad790d5aa9"
             ],
+            "index": "pypi",
             "version": "==0.4.4"
         },
         "pytz": {
@@ -118,17 +111,17 @@
         },
         "pyyaml": {
             "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
                 "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
                 "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
             "version": "==3.13"
         },
@@ -137,27 +130,30 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
+            "index": "pypi",
             "version": "==2.19.1"
         },
         "shapely": {
             "hashes": [
-                "sha256:13c82c9110e630039163bdcdb9969db4fadd145bcf633fc678fa762b01686e6d",
-                "sha256:cf02668c8633a41782b5244e04d5d0689847ac535cdf2fea66e4cac7dd772895",
-                "sha256:049e7732c58f8ee143899f9efbf714d8e7e3578443883c95614cfd4891d36502",
-                "sha256:c1f4d74e4c4a5681e77fbee5a7b0599a91ca39a8e260f2839a9a764382994f7f",
-                "sha256:41850cbfc79de117e3ccbc025b2eb7ee9170c29e65910003828e560ff076fc0d",
-                "sha256:a0db70e3384f1227bc40e22e9d77db3a54e02b54b48cf6b0c22ddfc0b688542d",
-                "sha256:592a7821c00ef4e0ae07e952366ad537313ccb7488665dd54b87e6f8eb31ef80",
-                "sha256:2222eba7f461f4b3f406b569727561f300ecd57e31e01b49ffd327dc4cbda632",
-                "sha256:e848bf533f0d6cbc336b4cf01dd1aa7873174ba7304a620baa7d663d1d0ce879",
-                "sha256:30df7572d311514802df8dc0e229d1660bc4cbdcf027a8281e79c5fc2fcf02f2"
+                "sha256:0378964902f89b8dbc332e5bdfa08e0bc2f7ab39fecaeb17fbb2a7699a44fe71",
+                "sha256:34e7c6f41fb27906ccdf2514ee44a5774b90b39a256b6511a6a57d11ffe64999",
+                "sha256:3ca69d4b12e2b05b549465822744b6a3a1095d8488cc27b2728a06d3c07d0eee",
+                "sha256:3e9388f29bd81fcd4fa5c35125e1fbd4975ee36971a87a90c093f032d0e9de24",
+                "sha256:3ef28e3f20a1c37f5b99ea8cf8dcb58e2f1a8762d65ed2d21fd92bf1d4811182",
+                "sha256:523c94403047eb6cacd7fc1863ebef06e26c04d8a4e7f8f182d49cd206fe787e",
+                "sha256:5d22a1a705c2f70f61ccadc696e33d922c1a92e00df8e1d58a6ade14dd7e3b4f",
+                "sha256:714b6680215554731389a1bbdae4cec61741aa4726921fa2b2b96a6f578a2534",
+                "sha256:7dfe1528650c3f0dc82f41a74cf4f72018288db9bfb75dcd08f6f04233ec7e78",
+                "sha256:ba58b21b9cf3c33725f7f530febff9ed6a6846f9d0bf8a120fc74683ff919f89",
+                "sha256:c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f",
+                "sha256:ebb4d2bee7fac3f6c891fcdafaa17f72ab9c6480f6d00de0b2dc9a5137dfe342"
             ],
-            "version": "==1.6.4.post1"
+            "version": "==1.6.4.post2"
         },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         },
@@ -165,19 +161,20 @@
             "hashes": [
                 "sha256:b9a056e60f6ad5d44e7bc9d397ae683ea4bcd81f812ab6bbdfaad3d9984fcf19"
             ],
+            "index": "pypi",
             "version": "==3.0.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
             "version": "==1.23"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b",
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
             ],
             "version": "==0.14.1"
         },
@@ -192,8 +189,8 @@
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6",
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585"
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
             ],
             "version": "==1.1.5"
         },
@@ -213,15 +210,15 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0",
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
             "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
         },
@@ -241,9 +238,10 @@
         },
         "freezegun": {
             "hashes": [
-                "sha256:94c59d69bb99c9ec3ca5a3adb41930d3ea09d2a9756c23a02d89fa75646e78dd",
-                "sha256:703caac155dcaad61f78de4cb0666dca778d854dfb90b3699930adee0559a622"
+                "sha256:703caac155dcaad61f78de4cb0666dca778d854dfb90b3699930adee0559a622",
+                "sha256:94c59d69bb99c9ec3ca5a3adb41930d3ea09d2a9756c23a02d89fa75646e78dd"
             ],
+            "index": "pypi",
             "version": "==0.3.10"
         },
         "idna": {
@@ -258,6 +256,7 @@
                 "sha256:a0c96853549b246991046f32d19db7140f5b1a644cc31f0dc1edc86713b7676f",
                 "sha256:eca537aa61592aca2fef4adea12af8e42f5c335004dfa80c78caf80e8b525e5c"
             ],
+            "index": "pypi",
             "version": "==6.4.0"
         },
         "ipython-genutils": {
@@ -269,8 +268,8 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:c254b135fb39ad76e78d4d8f92765ebc9bf92cbc76f49e97ade1d5f5121e1f6f",
-                "sha256:b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1"
+                "sha256:b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1",
+                "sha256:c254b135fb39ad76e78d4d8f92765ebc9bf92cbc76f49e97ade1d5f5121e1f6f"
             ],
             "version": "==0.12.1"
         },
@@ -278,65 +277,66 @@
             "hashes": [
                 "sha256:238ed21dd56d070dfd23e78663ecdb8ff49a7c24f5fa1c370e4fb95476f5b1ae"
             ],
+            "index": "pypi",
             "version": "==0.0.3"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0",
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
                 "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8"
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
             ],
             "version": "==4.2.0"
         },
         "parso": {
             "hashes": [
-                "sha256:8105449d86d858e53ce3e0044ede9dd3a395b1c9716c696af8aa3787158ab806",
-                "sha256:d250235e52e8f9fc5a80cc2a5f804c9fefd886b2e67a2b1099cf085f403f8e33"
+                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
+                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "pexpect": {
             "hashes": [
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b",
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba"
+                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
+                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
             ],
             "markers": "sys_platform != 'win32'",
             "version": "==4.6.0"
         },
         "pickleshare": {
             "hashes": [
-                "sha256:c9a2541f25aeabc070f12f452e1f2a8eae2abd51e1cd19e8430402bdf4c1d8b5",
-                "sha256:84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b"
+                "sha256:84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b",
+                "sha256:c9a2541f25aeabc070f12f452e1f2a8eae2abd51e1cd19e8430402bdf4c1d8b5"
             ],
             "version": "==0.7.4"
         },
         "pluggy": {
             "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
                 "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5",
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:3f473ae040ddaa52b52f97f6b4a493cfa9f5920c255a12dc56a7d34397a398a4",
                 "sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381",
+                "sha256:3f473ae040ddaa52b52f97f6b4a493cfa9f5920c255a12dc56a7d34397a398a4",
                 "sha256:858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917"
             ],
             "version": "==1.0.15"
         },
         "ptyprocess": {
             "hashes": [
-                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f",
-                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
             ],
             "version": "==0.6.0"
         },
         "py": {
             "hashes": [
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e",
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7"
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
             "version": "==1.5.4"
         },
@@ -349,9 +349,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d",
-                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752"
+                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
+                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
             ],
+            "index": "pypi",
             "version": "==3.6.3"
         },
         "python-dateutil": {
@@ -366,13 +367,15 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
+            "index": "pypi",
             "version": "==2.19.1"
         },
         "responses": {
             "hashes": [
-                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3",
-                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9"
+                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9",
+                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3"
             ],
+            "index": "pypi",
             "version": "==0.9.0"
         },
         "simplegeneric": {
@@ -383,29 +386,29 @@
         },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         },
         "traitlets": {
             "hashes": [
-                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9",
-                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835"
+                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
+                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
             ],
             "version": "==4.3.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
             "version": "==1.23"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c",
-                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
         }

--- a/idunn/blocks/opening_hour.py
+++ b/idunn/blocks/opening_hour.py
@@ -1,15 +1,12 @@
-import re
 import logging
-import datetime
-from datetime import datetime
-from pytz import country_timezones, timezone, UTC
-
-from apistar import validators
-from .base import BaseBlock
-
-import humanized_opening_hours as hoh
-from humanized_opening_hours.exceptions import ParseError, SpanOverMidnight
+from datetime import datetime, timedelta, date
+from pytz import timezone, UTC
+from apistar import validators, types
 from tzwhere import tzwhere
+from humanized_opening_hours.exceptions import ParseError, SpanOverMidnight
+
+from idunn.utils.opening_hours_lib import hoh
+from .base import BaseBlock
 
 """
 We load the tz structure once when Idunn starts since it's a time consuming step
@@ -40,6 +37,17 @@ def get_tz(es_poi):
             return timezone(tz.tzNameAt(lat, lon))
     return None
 
+
+class OpeningHoursType(types.Type):
+    beginning = validators.String()
+    end = validators.String()
+
+class DaysType(types.Type):
+    dayofweek = validators.Integer(minimum=1, maximum=7)
+    local_date = validators.Date()
+    status = validators.String(enum=['open', 'closed'])
+    opening_hours = validators.Array(items=OpeningHoursType)
+
 class OpeningHourBlock(BaseBlock):
     BLOCK_TYPE = 'opening_hours'
 
@@ -48,7 +56,7 @@ class OpeningHourBlock(BaseBlock):
     seconds_before_next_transition = validators.Integer()
     is_24_7 = validators.Boolean()
     raw = validators.String()
-    days = validators.Array()
+    days = validators.Array(items=DaysType)
 
     @classmethod
     def from_es(cls, es_poi, lang):
@@ -58,8 +66,9 @@ class OpeningHourBlock(BaseBlock):
         is247 = raw == '24/7'
 
         try:
-            clean_oh = hoh.OHParser.sanitize(raw)
-            oh = hoh.OHParser(clean_oh)
+            oh = hoh.OHParser(raw)
+            # Another hack in hoh: apply specific rules in priority
+            oh._tree.tree.children.sort(key=lambda x: len(x[0]))
         except ParseError:
             logging.info("Failed to parse OSM opening_hour field", exc_info=True)
             return None
@@ -74,9 +83,6 @@ class OpeningHourBlock(BaseBlock):
             logging.info("OSM opening_hour field cannot span over midnight", exc_info=True)
             return None
 
-        status = 'closed'
-        next_transition_datetime = ''
-        time_before_next = 0
         poi_tz = get_tz(es_poi)
         if poi_tz is not None:
             poi_dt = UTC.localize(datetime.utcnow()).astimezone(poi_tz)
@@ -84,20 +90,64 @@ class OpeningHourBlock(BaseBlock):
             # with an offset aware datetime.
             # This is why we replace the timezone info until this problem is fixed in the library.
             nt = oh.next_change(allow_recursion=False, moment=poi_dt.replace(tzinfo=None))
+
             # Then we localize the next_change transition datetime in the local POI timezone.
             next_transition = poi_tz.localize(nt.replace(tzinfo=None))
+            next_transition = cls.round_dt_to_minute(next_transition)
 
             next_transition_datetime = next_transition.isoformat()
             delta = next_transition - poi_dt
             time_before_next = int(delta.total_seconds())
+
             if oh.is_open(poi_dt):
                 status = 'open'
+            else:
+                status = 'closed'
 
-        return cls(
-            status=status,
-            next_transition_datetime=next_transition_datetime,
-            seconds_before_next_transition=time_before_next,
-            is_24_7=is247,
-            raw=raw,
-            days=[] # TODO: format to be defined
-        )
+            return cls(
+                status=status,
+                next_transition_datetime=next_transition_datetime,
+                seconds_before_next_transition=time_before_next,
+                is_24_7=is247,
+                raw=oh.sanitized_field,
+                days=cls.get_days(oh, dt=poi_dt)
+            )
+        else:
+            return None
+
+    @staticmethod
+    def round_dt_to_minute(dt):
+        dt += timedelta(seconds=30)
+        return dt.replace(second=0, microsecond=0)
+
+    @staticmethod
+    def round_time_to_minute(t):
+        dt = datetime.combine(date(2000,1,1), t)
+        rounded = OpeningHourBlock.round_dt_to_minute(dt)
+        return rounded.time()
+
+    @classmethod
+    def get_days(cls, oh_parser, dt):
+        last_monday = dt.date() - timedelta(days=dt.weekday())
+        days = []
+        for x in range(0,7):
+            day = last_monday + timedelta(days=x)
+            oh_day = oh_parser.get_day(day)
+            periods = oh_day.periods
+            day_value = {
+                'dayofweek': day.isoweekday(),
+                'local_date': day.isoformat(),
+                'status': 'open' if len(periods) > 0 else 'closed',
+                'opening_hours': []
+            }
+            for p in periods:
+                beginning = cls.round_time_to_minute(p.beginning.time())
+                end = cls.round_time_to_minute(p.end.time())
+                day_value['opening_hours'].append(
+                    {
+                        'beginning': beginning.strftime('%H:%M'),
+                        'end': end.strftime('%H:%M')
+                    }
+                )
+            days.append(day_value)
+        return days

--- a/idunn/blocks/services_and_information.py
+++ b/idunn/blocks/services_and_information.py
@@ -1,45 +1,68 @@
 from apistar import types, validators
 from .base import BaseBlock, BlocksValidator
 
+
 class AccessibilityBlock(BaseBlock):
     BLOCK_TYPE = "accessibility"
 
-    wheelchair = validators.String(enum=['true', 'false', 'limited'])
-    tactile_paving = validators.String(enum=['true', 'false', 'limited'])
-    toilets_wheelchair = validators.String(enum=['true', 'false', 'limited'])
+    STATUS_OK = "true"
+    STATUS_KO = "false"
+    STATUS_LIMITED = "limited"
+    STATUS_UNKNOWN = "unknown"
+
+    wheelchair = validators.String(
+        enum=[STATUS_OK, STATUS_KO, STATUS_LIMITED, STATUS_UNKNOWN]
+    )
+    tactile_paving = validators.String(enum=[STATUS_OK, STATUS_KO, STATUS_UNKNOWN])
+    toilets_wheelchair = validators.String(
+        enum=[STATUS_OK, STATUS_KO, STATUS_LIMITED, STATUS_UNKNOWN]
+    )
 
     @classmethod
     def from_es(cls, es_poi, lang):
-        properties = es_poi.get('properties', {})
+        properties = es_poi.get("properties", {})
 
-        raw_wheelchair = properties.get('wheelchair')
-        raw_tactile_paving = properties.get('tactile_paving')
-        raw_toilets_wheelchair = properties.get('toilets:wheelchair')
+        raw_wheelchair = properties.get("wheelchair")
+        raw_tactile_paving = properties.get("tactile_paving")
+        raw_toilets_wheelchair = properties.get("toilets:wheelchair")
 
-        if raw_wheelchair in ('yes', 'designated'):
-            wheelchair = 'true'
-        elif raw_wheelchair == 'limited':
-            wheelchair = 'limited'
+        if raw_wheelchair in ("yes", "designated"):
+            wheelchair = cls.STATUS_OK
+        elif raw_wheelchair == "limited":
+            wheelchair = cls.STATUS_LIMITED
+        elif raw_wheelchair == "no":
+            wheelchair = cls.STATUS_KO
         else:
-            wheelchair = 'false'
+            wheelchair = cls.STATUS_UNKNOWN
 
-        if raw_tactile_paving == 'yes':
-            tactile_paving = 'true'
-        elif raw_tactile_paving in ('contrasted', 'primitive', 'incorrect'):
-            tactile_paving = 'limited'
+        if raw_tactile_paving == "yes":
+            tactile_paving = cls.STATUS_OK
+        elif raw_tactile_paving == "no":
+            tactile_paving = cls.STATUS_KO
         else:
-            tactile_paving = 'false'
+            tactile_paving = cls.STATUS_UNKNOWN
 
-        if raw_toilets_wheelchair == 'yes':
-            toilets_wheelchair = 'true'
+        if raw_toilets_wheelchair == "yes":
+            toilets_wheelchair = cls.STATUS_OK
+        elif raw_toilets_wheelchair == "limited":
+            toilets_wheelchair = cls.STATUS_LIMITED
+        elif raw_toilets_wheelchair == "no":
+            toilets_wheelchair = cls.STATUS_KO
         else:
-            toilets_wheelchair = 'false'
+            toilets_wheelchair = cls.STATUS_UNKNOWN
+
+        if all(
+            s == cls.STATUS_UNKNOWN
+            for s in (wheelchair, tactile_paving, toilets_wheelchair)
+        ):
+            return None
 
         return cls(
             wheelchair=wheelchair,
             tactile_paving=tactile_paving,
-            toilets_wheelchair=toilets_wheelchair
+            toilets_wheelchair=toilets_wheelchair,
         )
+
 
 class InternetAccessBlock(BaseBlock):
     BLOCK_TYPE = "internet_access"
@@ -48,19 +71,21 @@ class InternetAccessBlock(BaseBlock):
 
     @classmethod
     def from_es(cls, es_poi, lang):
-        wifi = es_poi.get('properties', {}).get('wifi')
+        properties = es_poi.get("properties", {})
+        wifi = properties.get("wifi")
+        internet_access = properties.get("internet_access")
 
-        if wifi is None:
+        has_wifi = wifi in ("yes", "free") or internet_access in ("wlan", "wifi", "yes")
+
+        if not has_wifi:
             return None
 
-        wifi = wifi in ('yes', '*', 'free')
+        return cls(wifi=has_wifi)
 
-        return cls(
-            wifi=wifi
-        )
 
 class Beer(types.Type):
     name = validators.String()
+
 
 class BreweryBlock(BaseBlock):
     BLOCK_TYPE = "brewery"
@@ -69,21 +94,22 @@ class BreweryBlock(BaseBlock):
 
     @classmethod
     def from_es(cls, es_poi, lang):
-        brewery = es_poi.get('properties', {}).get('brewery')
+        brewery = es_poi.get("properties", {}).get("brewery")
 
         if brewery is None:
             return None
 
-        beers = [Beer(name=b) for b in brewery.split(';')]
+        beers = [Beer(name=b) for b in brewery.split(";")]
 
-        return cls(
-            beers=beers
-        )
+        return cls(beers=beers)
+
 
 class ServicesAndInformationBlock(BaseBlock):
     BLOCK_TYPE = "services_and_information"
 
-    blocks = BlocksValidator(allowed_blocks=[AccessibilityBlock, InternetAccessBlock, BreweryBlock])
+    blocks = BlocksValidator(
+        allowed_blocks=[AccessibilityBlock, InternetAccessBlock, BreweryBlock]
+    )
 
     @classmethod
     def from_es(cls, es_poi, lang):

--- a/idunn/utils/opening_hours_lib.py
+++ b/idunn/utils/opening_hours_lib.py
@@ -1,0 +1,25 @@
+import humanized_opening_hours as hoh
+from humanized_opening_hours.field_parser import WEEKDAYS, YearTransformer
+
+"""
+This is an ugly patch to work around a bug that caused
+an infinite loop when a day range overlaps the end of the week.
+eg: We-Mo
+
+This will be fixed in the next release of humanized_opening_hours,
+still in alpha to this day (2018-07-09)
+"""
+def patched_raw_consecutive_day_range(self, args):
+    """ Original implementation:
+    https://github.com/rezemika/humanized_opening_hours/blob/v0.6.2/humanized_opening_hours/field_parser.py#L70
+    """
+    first_day = WEEKDAYS.index(args[0])
+    last_day = WEEKDAYS.index(args[1])
+    if first_day <= last_day:
+        day_indexes = range(first_day, last_day+1)
+    else:
+        day_indexes = (i%7 for i in range(first_day, last_day+1+7))
+    return set(WEEKDAYS[i] for i in day_indexes)
+
+YearTransformer.raw_consecutive_day_range = patched_raw_consecutive_day_range
+hoh.field_parser.PARSER = hoh.field_parser.get_parser()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import pytest
+import responses
+import re
 from elasticsearch import Elasticsearch
-from app import app, settings
-from idunn.utils.settings import SettingsComponent
-from idunn.blocks.wikipedia import HTTPError40X
+
+from app import settings
 
 
 @pytest.fixture(scope='session')
@@ -63,3 +64,11 @@ def init_indices(mimir_client, wiki_client):
             }
         }
     )
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_external_requests():
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add('GET',
+                 re.compile('^https://.*\.wikipedia.org/'),
+                 status=404)
+        yield

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -5,16 +5,29 @@ def test_accessibility_block():
     web_block = AccessibilityBlock.from_es(
         {
             "properties": {
-                'wheelchair': 'yes',
-                'tactile_paving': 'incorrect',
-                'toilets_wheelchair': 'no'
+                'wheelchair': 'limited',
+                'tactile_paving': 'yes',
+                'toilets:wheelchair': 'no'
             }
         },
         lang='en'
     )
 
     assert web_block == AccessibilityBlock(
-        wheelchair='true',
-        tactile_paving='limited',
+        wheelchair='limited',
+        tactile_paving='true',
         toilets_wheelchair='false'
     )
+
+
+def test_accessibility_unknown():
+    web_block = AccessibilityBlock.from_es(
+        {
+            "properties": {
+                'wheelchair': 'toto',
+                'tactile_paving': 'unknown',
+            }
+        },
+        lang='en'
+    )
+    assert web_block is None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,22 +1,9 @@
 from apistar.test import TestClient
-from freezegun import freeze_time
 from app import app
 import pytest
 import json
 import os
-import re
-import responses
 
-
-# In this module all requests to external services
-# are mocked with RequestsMock
-@pytest.fixture(scope="module", autouse=True)
-def mock_external_requests():
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
-        rsps.add('GET',
-                 re.compile('^https://.*\.wikipedia.org/'),
-                 status=404)
-        yield
 
 def load_poi(file_name, mimir_client):
     """
@@ -177,8 +164,8 @@ def test_services_and_information(orsay_museum):
 	{
 	    "type": "accessibility",
 	    "wheelchair": "true",
-	    "tactile_paving": "false",
-	    "toilets_wheelchair": "false"
+	    "tactile_paving": "unknown",
+	    "toilets_wheelchair": "unknown"
 	},
 	{
 	    "type": "internet_access",

--- a/tests/test_api_with_wiki.py
+++ b/tests/test_api_with_wiki.py
@@ -1,66 +1,70 @@
 from apistar.test import TestClient
 from app import app
 import responses
+import pytest
 
 from .test_api import louvre_museum
 
+@pytest.fixture(scope='module', autouse=True)
+def mock_wikipedia_response():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://fr.wikipedia.org/w/api.php',
+            json={
+                "query": {
+                    "pages": [{
+                        "pageid": 69682,
+                        "ns": 0,
+                        "title": "Musée du Louvre",
+                        "langlinks": [{"lang": "es", "title": "Museo del Louvre"}]
+                    }]
+                }
+            }
+        )
 
-@responses.activate
+        rsps.add(
+            responses.GET,
+            'https://es.wikipedia.org/api/rest_v1/page/summary/Museo%20del%20Louvre',
+            json={  # This is a subset of the real response
+                "type": "standard",
+                "title": "Museo del Louvre",
+                "displaytitle": "Museo del Louvre",
+                "content_urls": {
+                    "desktop": {
+                        "page": "https://es.wikipedia.org/wiki/Museo_del_Louvre",
+                        "revisions": "https://es.wikipedia.org/wiki/Museo_del_Louvre?action=history",
+                        "edit": "https://es.wikipedia.org/wiki/Museo_del_Louvre?action=edit",
+                        "talk": "https://es.wikipedia.org/wiki/Discusión:Museo_del_Louvre"
+                    },
+                    "mobile": {
+                        "page": "https://es.m.wikipedia.org/wiki/Museo_del_Louvre",
+                        "revisions": "https://es.m.wikipedia.org/wiki/Special:History/Museo_del_Louvre",
+                        "edit": "https://es.m.wikipedia.org/wiki/Museo_del_Louvre?action=edit",
+                        "talk": "https://es.m.wikipedia.org/wiki/Discusión:Museo_del_Louvre"
+                    },
+                },
+                "api_urls": {
+                    "summary": "https://es.wikipedia.org/api/rest_v1/page/summary/Museo_del_Louvre",
+                    "metadata": "https://es.wikipedia.org/api/rest_v1/page/metadata/Museo_del_Louvre",
+                    "references": "https://es.wikipedia.org/api/rest_v1/page/references/Museo_del_Louvre",
+                    "media": "https://es.wikipedia.org/api/rest_v1/page/media/Museo_del_Louvre",
+                    "edit_html": "https://es.wikipedia.org/api/rest_v1/page/html/Museo_del_Louvre",
+                    "talk_page_html": "https://es.wikipedia.org/api/rest_v1/page/html/Discusión:Museo_del_Louvre"
+                },
+                "extract": "El Museo del Louvre es el museo nacional de Francia ...",
+                "extract_html": "<p>El <b>Museo del Louvre</b> es el museo nacional de Francia consagrado...</p>"
+            }
+        )
+        yield
+
+
 def test_wikipedia_another_language(louvre_museum):
     """
     The louvre museum has the tag 'wikipedia' with value 'fr:Musée du Louvre'
     We check that wikipedia block is built using data from the wikipedia page
     in another language.
     """
-    responses.add(
-        responses.GET,
-        'https://fr.wikipedia.org/w/api.php',
-        json={
-            "query":{
-                "pages": [{
-                    "pageid": 69682,
-                    "ns": 0,
-                    "title":"Musée du Louvre",
-                    "langlinks":[{"lang":"es","title":"Museo del Louvre"}]
-                }]
-            }
-        }
-    )
-
-    responses.add(
-        responses.GET,
-        'https://es.wikipedia.org/api/rest_v1/page/summary/Museo%20del%20Louvre',
-        json={ # This is a subset of the real response
-            "type": "standard",
-            "title": "Museo del Louvre",
-            "displaytitle": "Museo del Louvre",
-            "content_urls":{
-                "desktop": {
-                    "page": "https://es.wikipedia.org/wiki/Museo_del_Louvre",
-                    "revisions": "https://es.wikipedia.org/wiki/Museo_del_Louvre?action=history",
-                    "edit": "https://es.wikipedia.org/wiki/Museo_del_Louvre?action=edit",
-                    "talk": "https://es.wikipedia.org/wiki/Discusión:Museo_del_Louvre"
-                },
-                "mobile": {
-                    "page": "https://es.m.wikipedia.org/wiki/Museo_del_Louvre",
-                    "revisions": "https://es.m.wikipedia.org/wiki/Special:History/Museo_del_Louvre",
-                    "edit": "https://es.m.wikipedia.org/wiki/Museo_del_Louvre?action=edit",
-                    "talk": "https://es.m.wikipedia.org/wiki/Discusión:Museo_del_Louvre"
-                },
-            },
-            "api_urls": {
-                "summary": "https://es.wikipedia.org/api/rest_v1/page/summary/Museo_del_Louvre",
-                "metadata": "https://es.wikipedia.org/api/rest_v1/page/metadata/Museo_del_Louvre",
-                "references": "https://es.wikipedia.org/api/rest_v1/page/references/Museo_del_Louvre",
-                "media": "https://es.wikipedia.org/api/rest_v1/page/media/Museo_del_Louvre",
-                "edit_html": "https://es.wikipedia.org/api/rest_v1/page/html/Museo_del_Louvre",
-                "talk_page_html": "https://es.wikipedia.org/api/rest_v1/page/html/Discusión:Museo_del_Louvre"
-            },
-            "extract": "El Museo del Louvre es el museo nacional de Francia ...",
-            "extract_html": "<p>El <b>Museo del Louvre</b> es el museo nacional de Francia consagrado...</p>"
-        }
-    )
-
     client = TestClient(app)
     response = client.get(
         url=f'http://localhost/v1/pois/{louvre_museum}?lang=es',

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1,9 +1,10 @@
+import pytest
 from apistar.test import TestClient
 from freezegun import freeze_time
+
 from app import app
-import pytest
-import json
 from .test_api import load_poi
+
 
 @pytest.fixture(scope="module")
 def fake_all_blocks(mimir_client):
@@ -12,6 +13,7 @@ def fake_all_blocks(mimir_client):
     in order that Idunn returns all possible blocks.
     """
     return load_poi('fake_all_blocks.json', mimir_client)
+
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
 def test_full(fake_all_blocks):
@@ -47,11 +49,72 @@ def test_full(fake_all_blocks):
             {
                 "type": "opening_hours",
                 "status": "open",
-                "next_transition_datetime": "2018-06-14T18:00:00+02:00",
-                "seconds_before_next_transition": 27000,
+                "next_transition_datetime": "2018-06-14T21:45:00+02:00",
+                "seconds_before_next_transition": 40500,
                 "is_24_7": False,
                 "raw": "Tu-Su 09:30-18:00; Th 09:30-21:45",
-                "days": []
+                "days": [
+                    {
+                        "dayofweek": 1,
+                        "local_date": "2018-06-11",
+                        "status": "closed",
+                        "opening_hours": []
+                    },
+                    {
+                        "dayofweek": 2,
+                        "local_date": "2018-06-12",
+                        "status": "open",
+                        "opening_hours": [{
+                            'beginning': '09:30',
+                            'end': '18:00'
+                        }]
+                    },
+                    {
+                        "dayofweek": 3,
+                        "local_date": "2018-06-13",
+                        "status": "open",
+                        "opening_hours": [{
+                            'beginning': '09:30',
+                            'end': '18:00'
+                        }]
+                    },
+                    {
+                        "dayofweek": 4,
+                        "local_date": "2018-06-14",
+                        "status": "open",
+                        "opening_hours": [{
+                            'beginning': '09:30',
+                            'end': '21:45'
+                        }]
+                    },
+                    {
+                        "dayofweek": 5,
+                        "local_date": "2018-06-15",
+                        "status": "open",
+                        "opening_hours": [{
+                            'beginning': '09:30',
+                            'end': '18:00'
+                        }]
+                    },
+                    {
+                        "dayofweek": 6,
+                        "local_date": "2018-06-16",
+                        "status": "open",
+                        "opening_hours": [{
+                            'beginning': '09:30',
+                            'end': '18:00'
+                        }]
+                    },
+                    {
+                        "dayofweek": 7,
+                        "local_date": "2018-06-17",
+                        "status": "open",
+                        "opening_hours": [{
+                            'beginning': '09:30',
+                            'end': '18:00'
+                        }]
+                    },
+                ]
             },
             {
                 "type": "phone",
@@ -63,19 +126,13 @@ def test_full(fake_all_blocks):
                 "type": "information",
                 "blocks": [
                     {
-                        "type": "wikipedia",
-                        "url": "https://es.wikipedia.org/wiki/Museo_de_Orsay",
-                        "title": "Museo de Orsay",
-                        "description": "El Museo de Orsay es una pinacoteca ubicada en París (Francia), que se dedica a las artes plásticas del siglo XIX y, más en concreto, del periodo 1848-1914. Ocupa el antiguo edificio de la estación ferroviaria de Orsay y alberga la mayor colección de obras impresionistas del mundo, con obras maestras de la pintura y de la escultura como Almuerzo sobre la hierba y Olympia de Édouard Manet, una prueba de la estatua La pequeña bailarina de catorce años de Degas, Baile en el Moulin de la Galette de Renoir, varias obras esenciales de Courbet e incluso cinco cuadros de la Serie des Catedrales de Rouen de Monet. Cronológicamente, este museo cubre la historia del arte entre los maestros antiguos y el arte moderno y contemporáneo."
-                    },
-                    {
                         "type": "services_and_information",
                         "blocks": [
                             {
                                 "type": "accessibility",
                                 "wheelchair": "true",
-                                "tactile_paving": "false",
-                                "toilets_wheelchair": "false"
+                                "tactile_paving": "unknown",
+                                "toilets_wheelchair": "unknown"
                             },
                             {
                                 "type": "internet_access",

--- a/tests/test_internet_access.py
+++ b/tests/test_internet_access.py
@@ -10,7 +10,18 @@ def test_internet_access_block():
         },
         lang='en'
     )
+    assert web_block is None
 
+
+def test_internet_access_block_ok():
+    web_block = InternetAccessBlock.from_es(
+        {
+            "properties": {
+                "internet_access": "wlan"
+            }
+        },
+        lang='en'
+    )
     assert web_block == InternetAccessBlock(
-        wifi=False
+        wifi=True
     )

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -1,6 +1,5 @@
-from app import app
 from freezegun import freeze_time
-from apistar.test import TestClient
+from unittest.mock import ANY
 from idunn.blocks.opening_hour import OpeningHourBlock
 
 """
@@ -46,12 +45,56 @@ def test_opening_hour_open():
     oh_block = get_moscow_poi("Mo-Su 10:00-22:00")
 
     assert oh_block == OpeningHourBlock(
+        type='opening_hours',
         status='open',
         next_transition_datetime='2018-06-14T22:00:00+03:00',
         seconds_before_next_transition=37800,
         is_24_7=False,
         raw='Mo-Su 10:00-22:00',
-        days=[]
+        days=[
+            {
+                "dayofweek": 1,
+                "local_date": "2018-06-11",
+                "status": "open",
+                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+            },
+            {
+                "dayofweek": 2,
+                "local_date": "2018-06-12",
+                "status": "open",
+                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+            },
+            {
+                "dayofweek": 3,
+                "local_date": "2018-06-13",
+                "status": "open",
+                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+            },
+            {
+                "dayofweek": 4,
+                "local_date": "2018-06-14",
+                "status": "open",
+                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+            },
+            {
+                "dayofweek": 5,
+                "local_date": "2018-06-15",
+                "status": "open",
+                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+            },
+            {
+                "dayofweek": 6,
+                "local_date": "2018-06-16",
+                "status": "open",
+                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+            },
+            {
+                "dayofweek": 7,
+                "local_date": "2018-06-17",
+                "status": "open",
+                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+            },
+        ]
     )
 
 @freeze_time("2018-06-14 21:30:00", tz_offset=0)
@@ -62,14 +105,14 @@ def test_opening_hour_close():
     """
     oh_block = get_moscow_poi("Mo-Su 10:00-22:00")
 
-    assert oh_block == OpeningHourBlock(
-        status='closed',
-        next_transition_datetime='2018-06-15T10:00:00+03:00',
-        seconds_before_next_transition=34200,
-        is_24_7=False,
-        raw='Mo-Su 10:00-22:00',
-        days=[]
-    )
+    assert oh_block.status == 'closed'
+    assert oh_block.next_transition_datetime == '2018-06-15T10:00:00+03:00'
+    assert oh_block.seconds_before_next_transition == 34200
+    assert oh_block.is_24_7 ==  False
+    assert oh_block.raw == 'Mo-Su 10:00-22:00'
+    assert len(oh_block.days) == 7
+    assert all(d.status == 'open' for d in oh_block.days)
+
 
 @freeze_time("2018-06-14 21:30:00", tz_offset=0)
 def test_opening_hour_next_year():
@@ -79,11 +122,91 @@ def test_opening_hour_next_year():
     """
     oh_block = get_moscow_poi("Jan-Feb 10:00-20:00")
 
-    assert oh_block == OpeningHourBlock(
+    assert dict(oh_block) == dict(
+        type='opening_hours',
         status='closed',
         next_transition_datetime='2019-01-01T10:00:00+03:00',
         seconds_before_next_transition=17314200,
         is_24_7=False,
         raw='Jan-Feb 10:00-20:00',
-        days=[]
+        days=ANY
+    )
+    assert len(oh_block.days) == 7
+    assert all(d.status == 'closed' for d in oh_block.days)
+
+
+@freeze_time("2018-06-14T23:00:00+03:00")
+def test_opening_hour_open_until_midnight():
+    oh_block = get_moscow_poi("Mo-Su 09:00-00:00")
+    assert oh_block == dict(
+        type='opening_hours',
+        status='open',
+        next_transition_datetime='2018-06-15T00:00:00+03:00',
+        seconds_before_next_transition=3600,
+        is_24_7=False,
+        raw='Mo-Su 09:00-24:00',
+        days=ANY
+    )
+    assert len(oh_block.days) == 7
+    assert all(d.status == 'open' for d in oh_block.days)
+    assert all(d.opening_hours == [dict(
+        beginning='09:00',
+        end='00:00'
+    )] for d in oh_block.days)
+
+
+@freeze_time("2018-06-15T21:00:00+03:00")
+def test_opening_hour_days_cycle():
+    oh_block = get_moscow_poi("We-Mo 11:00-19:00")
+    assert oh_block == dict(
+        type='opening_hours',
+        status='closed',
+        next_transition_datetime='2018-06-16T11:00:00+03:00',
+        seconds_before_next_transition=50400,
+        is_24_7=False,
+        raw='We-Mo 11:00-19:00',
+        days=[
+            {
+                "dayofweek": 1,
+                "local_date": "2018-06-11",
+                "status": "open",
+                "opening_hours": [{"beginning": "11:00", "end": "19:00"}]
+            },
+            {
+                "dayofweek": 2,
+                "local_date": "2018-06-12",
+                "status": "closed",
+                "opening_hours": []
+            },
+            {
+                "dayofweek": 3,
+                "local_date": "2018-06-13",
+                "status": "open",
+                "opening_hours": [{"beginning": "11:00", "end": "19:00"}]
+            },
+            {
+                "dayofweek": 4,
+                "local_date": "2018-06-14",
+                "status": "open",
+                "opening_hours": [{"beginning": "11:00", "end": "19:00"}]
+            },
+            {
+                "dayofweek": 5,
+                "local_date": "2018-06-15",
+                "status": "open",
+                "opening_hours": [{"beginning": "11:00", "end": "19:00"}]
+            },
+            {
+                "dayofweek": 6,
+                "local_date": "2018-06-16",
+                "status": "open",
+                "opening_hours": [{"beginning": "11:00", "end": "19:00"}]
+            },
+            {
+                "dayofweek": 7,
+                "local_date": "2018-06-17",
+                "status": "open",
+                "opening_hours": [{"beginning": "11:00", "end": "19:00"}]
+            },
+        ]
     )

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -37,12 +37,12 @@ def get_moscow_poi(opening_hours):
 @freeze_time("2018-06-14 8:30:00", tz_offset=0)
 def test_opening_hour_open():
     """
-    We freeze time at 8h30 UTC (ie. 11h30 Moscow)
+    We freeze time at 8:30 UTC (ie. 11:30 in Moscow)
     The POI located in Moscow should be open since
-    it opens at 10h00 every day and the local time
-    is 11h30.
+    it opens at 10:00 every day and the local time
+    is 11:30.
     """
-    oh_block = get_moscow_poi("Mo-Su 10:00-22:00")
+    oh_block = get_moscow_poi("Mo-Sa 10:00-22:00; Su 10:00-14:00, 18:00-22:00")
 
     assert oh_block == OpeningHourBlock(
         type='opening_hours',
@@ -50,7 +50,7 @@ def test_opening_hour_open():
         next_transition_datetime='2018-06-14T22:00:00+03:00',
         seconds_before_next_transition=37800,
         is_24_7=False,
-        raw='Mo-Su 10:00-22:00',
+        raw='Mo-Sa 10:00-22:00; Su 10:00-14:00,18:00-22:00',
         days=[
             {
                 "dayofweek": 1,
@@ -92,7 +92,10 @@ def test_opening_hour_open():
                 "dayofweek": 7,
                 "local_date": "2018-06-17",
                 "status": "open",
-                "opening_hours": [{"beginning": "10:00", "end": "22:00"}]
+                "opening_hours": [
+                    {"beginning": "10:00", "end": "14:00"},
+                    {"beginning": "18:00", "end": "22:00"},
+                ]
             },
         ]
     )
@@ -157,6 +160,10 @@ def test_opening_hour_open_until_midnight():
 
 @freeze_time("2018-06-15T21:00:00+03:00")
 def test_opening_hour_days_cycle():
+    """
+    Opening_hours values where a day range ends with Monday,
+    to test if the "cycle" is parsed correctly.
+    """
     oh_block = get_moscow_poi("We-Mo 11:00-19:00")
     assert oh_block == dict(
         type='opening_hours',

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -1,13 +1,14 @@
 from apistar.test import TestClient
 from freezegun import freeze_time
-from app import app, settings
 import pytest
 import os
 import re
 import json
-from .test_api import load_poi
 import responses
-from .test_api import orsay_museum
+
+from app import app, settings
+from .test_api import load_poi, orsay_museum
+
 
 @pytest.fixture(scope="session")
 def basket_ball_wiki_es(wiki_client, init_indices):

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -27,7 +27,7 @@ def basket_ball_wiki_es(wiki_client, init_indices):
         return poi_id
 
 @pytest.fixture(scope="session")
-def basket_ball(mimir_client):
+def basket_ball(mimir_client, init_indices):
     """
     fill elasticsearch with a fake POI of basket ball
     """
@@ -103,8 +103,8 @@ def test_POI_not_in_WIKI_ES(orsay_museum, basket_ball_wiki_es):
             {
                 "type": "accessibility",
                 "wheelchair": "true",
-                "tactile_paving": "false",
-                "toilets_wheelchair": "false"
+                "tactile_paving": "unknown",
+                "toilets_wheelchair": "unknown"
             },
             {
                 "type": "internet_access",


### PR DESCRIPTION
* Implement detailed "days" in "opening_hours"
* Work around multiple bugs in humanized_opening_hours (waiting for the next release that should solve these issues)
* Do not return "accessibility" block when all values are missing / unknown
* Improve "internet_access" block (using "internet_access" tag from osm)
* Use a session fixture in tests, to mock all external calls to wikipedia by default
