### PR TITLE
Bypass Wikipedia API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run the api you need to do:
 `pipenv install`
 
 and then
-`IDUNN_ES_URL=<url_to_elasticsearch> IDUNN_ES_WIKI_LANG=<comma_separated_languages> IDUNN_WIKI_ES=<url_to_WIKI_ES> pipenv run python app.py`
+`IDUNN_MIMIR_ES=<url_to_elasticsearch> IDUNN_WIKI_ES=<url_to_WIKI_ES> pipenv run python app.py`
 
 you can query the API on 5000:
 `curl localhost:5000/v1/pois/toto?lang=fr`
@@ -36,7 +36,7 @@ The configuration can be given from different ways:
  2. a yaml settings file can be given with an env var IDUNN_CONFIG_FILE
     (the default settings is still loaded and overriden)
  3. specific variable can be overriden with env var. They need to be given like "IDUNN_{var_name}={value}"
-    eg IDUNN_ES_URL=...
+    eg IDUNN_MIMIR_ES=...
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run the api you need to do:
 `pipenv install`
 
 and then
-`IDUNN_MIMIR_ES=<url_to_elasticsearch> IDUNN_WIKI_ES=<url_to_WIKI_ES> pipenv run python app.py`
+`IDUNN_MIMIR_ES=<url_to_MIMIR_ES> IDUNN_WIKI_ES=<url_to_WIKI_ES> pipenv run python app.py`
 
 you can query the API on 5000:
 `curl localhost:5000/v1/pois/toto?lang=fr`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run the api you need to do:
 `pipenv install`
 
 and then
-`IDUNN_ES_URL=<url_to_elasticsearch> pipenv run python app.py`
+`IDUNN_ES_URL=<url_to_elasticsearch> IDUNN_ES_WIKI_LANG=<comma_separated_languages> IDUNN_WIKI_ES=<url_to_WIKI_ES> pipenv run python app.py`
 
 you can query the API on 5000:
 `curl localhost:5000/v1/pois/toto?lang=fr`

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -148,11 +148,8 @@ class WikidataConnector:
             return None
 
         wiki = resp[0]['_source']
-        return (
-            wiki.get("url"),
-            wiki.get("title"),
-            wiki.get("content")
-        )
+
+        return wiki
 
 class WikipediaBlock(BaseBlock):
     BLOCK_TYPE = "wikipedia"
@@ -178,9 +175,9 @@ class WikipediaBlock(BaseBlock):
                     wiki_poi_info = WikidataConnector.get_wiki_info(wikidata_id, lang, wiki_index)
                     if wiki_poi_info is not None:
                         return cls(
-                            url=wiki_poi_info[0],
-                            title=wiki_poi_info[1][0],
-                            description=wiki_poi_info[2],
+                            url=wiki_poi_info.get("url"),
+                            title=wiki_poi_info.get("title")[0],
+                            description=wiki_poi_info.get("content"),
                         )
                     else:
                         """

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -106,14 +106,10 @@ class Wikidata:
     _es_lang = None
 
     @classmethod
-    def init_lang(cls):
-        from app import settings
-        cls._es_lang = settings['ES_WIKI_LANG'].split(',')
-
-    @classmethod
     def get_wiki_index(cls, lang):
         if cls._es_lang is None:
-            cls.init_lang()
+            from app import settings
+            cls._es_lang = settings['ES_WIKI_LANG'].split(',')
         if lang in cls._es_lang:
             return "wikidata_{}".format(lang)
         return None
@@ -143,7 +139,11 @@ class Wikidata:
             return None
 
         wiki = resp[0]['_source']
-        return (wiki.get("url"), wiki.get("title"), wiki.get("content"))
+        return (
+            wiki.get("url"),
+            wiki.get("title"),
+            wiki.get("content")
+        )
 
 class WikipediaBlock(BaseBlock):
     BLOCK_TYPE = "wikipedia"
@@ -157,9 +157,9 @@ class WikipediaBlock(BaseBlock):
     @classmethod
     def from_es(cls, es_poi, lang):
         """
-        If wikidata id is present, then we fetch our WIKI_ES,
-        else if the request lang is not in the lang white list,
-        then we fetch the wikipedia API.
+        If "wikidata_id" is present and "lang" is in "ES_WIKI_LANG",
+        then we try to fetch our "WIKI_ES",
+        else then we fetch the wikipedia API.
         """
         wikidata_id = es_poi.get("properties", {}).get("wikidata")
         if wikidata_id is not None:

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -1,6 +1,8 @@
 
 ES_URL: http://localhost:9200/
 
+WIKI_ES: http://localhost:9200/
+
 WIKI_USER_AGENT: 'Idunn' # Used in requests to external wiki* APIs
 
 DEFAULT_LANGUAGE: 'en' # Fallback when no 'lang' in request
@@ -8,3 +10,5 @@ DEFAULT_LANGUAGE: 'en' # Fallback when no 'lang' in request
 WIKI_API_CIRCUIT_TIMEOUT: 120
 
 WIKI_API_CIRCUIT_MAXFAIL: 50
+
+ES_WIKI_LANG: "de,en,es,fr,it"

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -1,7 +1,7 @@
 
-ES_URL: http://localhost:9200/
+MIMIR_ES: http://localhost:9200/
 
-WIKI_ES: http://localhost:9200/
+WIKI_ES:
 
 WIKI_USER_AGENT: 'Idunn' # Used in requests to external wiki* APIs
 
@@ -11,4 +11,4 @@ WIKI_API_CIRCUIT_TIMEOUT: 120
 
 WIKI_API_CIRCUIT_MAXFAIL: 50
 
-ES_WIKI_LANG: "de,en,es,fr,it"
+ES_WIKI_LANG: "de,en,es,fr,it" # the (comma separated) list of languages existing in the WIKI_ES

--- a/idunn/utils/es_wrapper.py
+++ b/idunn/utils/es_wrapper.py
@@ -19,4 +19,4 @@ class ElasticSearchComponent(Component):
         return self._es
 
     def _make_client(self, settings) -> Elasticsearch:
-        self._es = Elasticsearch(settings['ES_URL'])
+        self._es = Elasticsearch(settings['MIMIR_ES'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,25 @@
 import pytest
 from elasticsearch import Elasticsearch
-from app import app
+from app import app, settings
 from idunn.utils.settings import SettingsComponent
 from idunn.blocks.wikipedia import HTTPError40X
 
 
 @pytest.fixture(scope='session')
-def es(docker_services):
+def mimir_es(docker_services):
     """Ensure that ES is up and responsive."""
-    docker_services.start('elasticsearch')
-    port = docker_services.wait_for_service("elasticsearch", 9200)
+    docker_services.start('mimir_es')
+    port = docker_services.wait_for_service("mimir_es", 9200)
 
     url = f'http://{docker_services.docker_ip}:{port}'
 
-    # we override the settings to set the ES_URL
-    for c in app.injector.components:
-        if isinstance(c, SettingsComponent):
-            c._settings['ES_URL'] = url
+    # we override the settings to set the MIMIR_ES
+    settings._settings['MIMIR_ES'] = url
     return url
 
-
 @pytest.fixture(scope='session')
-def es_client(es):
-    return Elasticsearch([es])
-
+def mimir_client(mimir_es):
+    return Elasticsearch([mimir_es])
 
 @pytest.fixture(scope='session')
 def wiki_es(docker_services):
@@ -33,29 +29,26 @@ def wiki_es(docker_services):
 
     url = f'http://{docker_services.docker_ip}:{port}'
 
-    for c in app.injector.components:
-        if isinstance(c, SettingsComponent):
-            c._settings['WIKI_ES'] = url
-            c._settings['ES_WIKI_LANG'] = 'fr'
+    settings._settings['WIKI_ES'] = url
+    settings._settings['ES_WIKI_LANG'] = 'fr'
     return url
 
 
 @pytest.fixture(scope='session')
-def wiki_es_client(wiki_es):
+def wiki_client(wiki_es):
     return Elasticsearch([wiki_es])
 
-
 @pytest.fixture(scope="session")
-def init_indices(es_client, wiki_es_client):
+def init_indices(mimir_client, wiki_client):
     """
     Init the elastic index with the 'munin_poi_specific' index and alias it to 'munin_poi' as mimir does
     """
     index_name = 'munin_poi_specific'
-    es_client.indices.create(index=index_name)
-    es_client.indices.put_alias(name='munin_poi', index=index_name)
+    mimir_client.indices.create(index=index_name)
+    mimir_client.indices.put_alias(name='munin_poi', index=index_name)
 
     index_name = 'wikidata_fr'
-    wiki_es_client.indices.create(
+    wiki_client.indices.create(
         index=index_name,
         body={
             "mappings": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,3 +23,50 @@ def es(docker_services):
 @pytest.fixture(scope='session')
 def es_client(es):
     return Elasticsearch([es])
+
+
+@pytest.fixture(scope='session')
+def wiki_es(docker_services):
+    """Ensure that ES is up and responsive."""
+    docker_services.start('wiki_es')
+    port = docker_services.wait_for_service("wiki_es", 9200)
+
+    url = f'http://{docker_services.docker_ip}:{port}'
+
+    for c in app.injector.components:
+        if isinstance(c, SettingsComponent):
+            c._settings['WIKI_ES'] = url
+            c._settings['ES_WIKI_LANG'] = 'fr'
+    return url
+
+
+@pytest.fixture(scope='session')
+def wiki_es_client(wiki_es):
+    return Elasticsearch([wiki_es])
+
+
+@pytest.fixture(scope="session")
+def init_indices(es_client, wiki_es_client):
+    """
+    Init the elastic index with the 'munin_poi_specific' index and alias it to 'munin_poi' as mimir does
+    """
+    index_name = 'munin_poi_specific'
+    es_client.indices.create(index=index_name)
+    es_client.indices.put_alias(name='munin_poi', index=index_name)
+
+    index_name = 'wikidata_fr'
+    wiki_es_client.indices.create(
+        index=index_name,
+        body={
+            "mappings": {
+                "wikipedia": {
+                    "properties": {
+                        "wikibase_item": {
+                            "type": "string",
+                            "analyzer": "keyword"
+                        }
+                    }
+                }
+            }
+        }
+    )

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,3 +5,8 @@ services:
     image: elasticsearch:2-alpine
     ports:
     - "9200"
+
+  wiki_es:
+    image: elasticsearch:2-alpine
+    ports:
+        - "9201:9200"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  elasticsearch:
+  mimir_es:
     image: elasticsearch:2-alpine
     ports:
     - "9200"
@@ -9,4 +9,4 @@ services:
   wiki_es:
     image: elasticsearch:2-alpine
     ports:
-        - "9201:9200"
+        - "9200"

--- a/tests/fixtures/basket_ball.json
+++ b/tests/fixtures/basket_ball.json
@@ -1,0 +1,127 @@
+{
+  "address": {
+    "city": "Paris",
+    "citycode": "75056",
+    "housenumber": "62B",
+    "id": "addr:2.326285;48.859635",
+    "label": "62B Rue de Lille (Paris)",
+    "name": "62B Rue de Lille",
+    "postcode": "75007",
+    "street": "Rue de Lille",
+    "type": "house"
+  },
+  "city": "Paris",
+  "citycode": "75056",
+  "id": "osm:way:7777777",
+  "label": "Fake All (Paris)",
+  "name": "Fake All",
+  "coord": {
+	"lon": 2.3250037768187326,
+	"lat": 48.86618482685007
+  },
+  "poi_types": [
+    {
+      "id": "museum",
+      "name": "museum"
+    }
+  ],
+  "postcode": null,
+  "properties": [
+    {
+      "key": "website",
+      "value": "http://www.musee-orsay.fr"
+    },
+    {
+      "key": "wikidata",
+      "value": "Q21657967"
+    },
+    {
+      "key": "wikipedia",
+      "value": "fr:Musée d'Orsay"
+    },
+    {
+      "key": "description:fr",
+      "value": "Collections : Art français et européen de 1848 à 1914"
+    },
+    {
+      "key": "tourism:visitors",
+      "value": "3500000"
+    },
+    {
+      "key": "addr:postcode",
+      "value": "75007"
+    },
+    {
+      "key": "name",
+      "value": "Fake All"
+    },
+    {
+      "key": "name:es",
+      "value": "Fako Allo"
+    },
+    {
+      "key": "wheelchair",
+      "value": "yes"
+    },
+    {
+      "key": "tourism",
+      "value": "museum"
+    },
+    {
+      "key": "name:fr",
+      "value": "Musée d'Orsay"
+    },
+    {
+      "key": "contact:email",
+      "value": "contact@example.com"
+    },
+    {
+      "key": "brewery",
+      "value": "Kilkenny;Guinness"
+    },
+    {
+      "wifi": "yes"
+    },
+    {
+      "key": "phone",
+      "value": "+33140494814"
+    },
+    {
+      "key": "building",
+      "value": "train_station"
+    },
+    {
+      "key": "addr:street",
+      "value": "Rue de la Légion d'Honneur"
+    },
+    {
+      "key": "opening_hours",
+      "value": "Tu-Su 09:30-18:00; Th 09:30-21:45"
+    },
+    {
+      "key": "poi_subclass",
+      "value": "museum"
+    },
+    {
+      "key": "poi_class",
+      "value": "museum"
+    },
+    {
+      "key": "wifi",
+      "value": "yes"
+    },
+    {
+      "key": "contact:website",
+      "value": "http://testing.test"
+    },
+    {
+      "key": "wheelchair",
+      "value": "yes"
+    },
+    {
+      "key": "mail",
+      "value": "mailto:contact@example.com"
+    }
+  ],
+  "type": "poi"
+}

--- a/tests/fixtures/basket_ball_wiki_es.json
+++ b/tests/fixtures/basket_ball_wiki_es.json
@@ -1,0 +1,26 @@
+{
+	"ambiguity_page": false,
+	"source_text": "fortest",
+	"infobox": {
+		"official": "http://www.ltb29.fr/",
+		"type": "",
+		"subname": "",
+		"name": "club de basket-ball"
+	},
+	"wikibase_item": "Q21657967",
+	"redirect": false,
+	"title": [
+		"Pleyber-Christ Basket Club"
+	],
+	"originalTitle": "Pleyber-Christ Basket Club",
+	"url": "https://fr.wikipedia.org/wiki/Pleyber-Christ_Basket_Club",
+	"popularity_score": 5.5682574382113e-8,
+	"category": [
+		"Club sportif de test"
+	],
+	"pageimage_original": "",
+	"pageimage_thumb": "",
+	"id": "6544690",
+	"content": "Le Pleyber-Christ Basket Club est un club français de basket-ball dont la section senior féminine a accédé jusqu'au championnat professionnel de Ligue 2 (2e division nationale), performance remarquée pour un village de 3000 habitants. Le club est basé dans la ville de Pleyber-Christ. Il accueille aussi de jeunes joueuses depuis 2010 dans son centre de formation situé à Pleyber-Christ.",
+	"content_length": 387
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,7 @@ def mock_external_requests():
                  status=404)
         yield
 
-def load_poi(file_name, es_client):
+def load_poi(file_name, mimir_client):
     """
     Load a json file in the elasticsearch and returns the corresponding POI id
     """
@@ -26,7 +26,7 @@ def load_poi(file_name, es_client):
     with open(filepath, "r") as f:
         poi = json.load(f)
         poi_id = poi['id']
-        es_client.index(index='munin_poi',
+        mimir_client.index(index='munin_poi',
                         body=poi,
                         doc_type='poi',
                         id=poi_id,
@@ -34,25 +34,25 @@ def load_poi(file_name, es_client):
         return poi_id
 
 @pytest.fixture(scope="session")
-def orsay_museum(es_client, init_indices):
+def orsay_museum(mimir_client, init_indices):
     """
     fill elasticsearch with the orsay museum
     """
-    return load_poi('orsay_museum.json', es_client)
+    return load_poi('orsay_museum.json', mimir_client)
 
 @pytest.fixture(scope="session")
-def blancs_manteaux(es_client, init_indices):
+def blancs_manteaux(mimir_client, init_indices):
     """
     fill elasticsearch with the church des blancs manteaux
     """
-    return load_poi('blancs_manteaux.json', es_client)
+    return load_poi('blancs_manteaux.json', mimir_client)
 
 @pytest.fixture(scope="session")
-def louvre_museum(init_indices, es_client):
+def louvre_museum(init_indices, mimir_client):
     """
     fill elasticsearch with the louvre museum (with the tag 'contact:phone')
     """
-    return load_poi('louvre_museum.json', es_client)
+    return load_poi('louvre_museum.json', mimir_client)
 
 def test_basic_query(orsay_museum):
     client = TestClient(app)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,20 +12,11 @@ import responses
 # are mocked with RequestsMock
 @pytest.fixture(scope="module", autouse=True)
 def mock_external_requests():
-    with responses.RequestsMock() as rsps:
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add('GET',
                  re.compile('^https://.*\.wikipedia.org/'),
                  status=404)
         yield
-
-@pytest.fixture(scope="session")
-def init_indices(es_client):
-    """
-    Init the elastic index with the 'munin_poi_specific' index and alias it to 'munin_poi' as mimir does
-    """
-    index_name = 'munin_poi_specific'
-    es_client.indices.create(index=index_name)
-    es_client.indices.put_alias(name='munin_poi', index=index_name)
 
 def load_poi(file_name, es_client):
     """
@@ -42,22 +33,22 @@ def load_poi(file_name, es_client):
                         refresh=True)
         return poi_id
 
-@pytest.fixture(scope="module")
-def orsay_museum(es_client):
+@pytest.fixture(scope="session")
+def orsay_museum(es_client, init_indices):
     """
     fill elasticsearch with the orsay museum
     """
     return load_poi('orsay_museum.json', es_client)
 
-@pytest.fixture(scope="module")
-def blancs_manteaux(es_client):
+@pytest.fixture(scope="session")
+def blancs_manteaux(es_client, init_indices):
     """
     fill elasticsearch with the church des blancs manteaux
     """
     return load_poi('blancs_manteaux.json', es_client)
 
-@pytest.fixture(scope="module")
-def louvre_museum(es_client):
+@pytest.fixture(scope="session")
+def louvre_museum(init_indices, es_client):
     """
     fill elasticsearch with the louvre museum (with the tag 'contact:phone')
     """

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -6,7 +6,7 @@ from elasticsearch.exceptions import ConnectionError
 from app import app
 
 
-def test_v1_status_ok(es):
+def test_v1_status_ok(mimir_es):
     client = TestClient(app)
     response = client.get("http://localhost/v1/status")
 
@@ -15,7 +15,7 @@ def test_v1_status_ok(es):
 
 
 @patch.object(ClusterClient, "health", new=lambda *args: {"status": "red"})
-def test_v1_status_es_red(es):
+def test_v1_status_es_red(mimir_es):
     client = TestClient(app)
     response = client.get("http://localhost/v1/status")
 
@@ -24,7 +24,7 @@ def test_v1_status_es_red(es):
 
 
 @patch.object(ClusterClient, "health")
-def test_v1_status_es_unreachable(mock_es_health, es):
+def test_v1_status_es_unreachable(mock_es_health, mimir_es):
     mock_es_health.side_effect = ConnectionError
 
     client = TestClient(app)

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -6,12 +6,12 @@ import json
 from .test_api import load_poi
 
 @pytest.fixture(scope="module")
-def fake_all_blocks(es_client):
+def fake_all_blocks(mimir_client):
     """
     fill elasticsearch with a fake POI that contains all information possible
     in order that Idunn returns all possible blocks.
     """
-    return load_poi('fake_all_blocks.json', es_client)
+    return load_poi('fake_all_blocks.json', mimir_client)
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
 def test_full(fake_all_blocks):

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -1,0 +1,71 @@
+from apistar.test import TestClient
+from freezegun import freeze_time
+from app import app
+import pytest
+import os
+import re
+import json
+from .test_api import load_poi
+import responses
+
+@pytest.fixture(scope="session")
+def basket_ball_wiki_es(wiki_es_client, init_indices):
+    """
+    fill the elasticsearch WIKI_ES with a POI of basket ball
+    """
+    filepath = os.path.join(os.path.dirname(__file__), 'fixtures', 'basket_ball_wiki_es.json')
+    with open(filepath, "r") as f:
+        poi = json.load(f)
+        poi_id = poi['id']
+        wiki_es_client.index(index='wikidata_fr',
+                        body=poi,
+                        doc_type='wikipedia',
+                        id=poi_id,
+                        refresh=True)
+        return poi_id
+
+@pytest.fixture(scope="session")
+def basket_ball(es_client):
+    """
+    fill elasticsearch with a fake POI of basket ball
+    """
+    return load_poi('basket_ball.json', es_client)
+
+@freeze_time("2018-06-14 8:30:00", tz_offset=2)
+def test_basket_ball(basket_ball, basket_ball_wiki_es):
+    """
+    Check that the wikipedia block contains the correct
+    information about a POI that is in the WIKI_ES.
+    """
+    client = TestClient(app)
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add('GET',
+             re.compile('^https://.*\.wikipedia.org/'),
+             status=200)
+
+        response = client.get(
+            url=f'http://localhost/v1/pois/{basket_ball}?lang=fr',
+        )
+
+        assert response.status_code == 200
+
+        resp = response.json()
+
+        assert resp['blocks'][2].get('blocks')[0] == {
+            'type': 'wikipedia',
+            'url': 'https://fr.wikipedia.org/wiki/Pleyber-Christ_Basket_Club',
+            'title': 'Pleyber-Christ Basket Club',
+            'description': "Le Pleyber-Christ Basket Club est un club français de basket-ball dont la section senior féminine a accédé jusqu'au championnat professionnel de Ligue 2 (2e division nationale), performance remarquée pour un village de 3000 habitants. Le club est basé dans la ville de Pleyber-Christ. Il accueille aussi de jeunes joueuses depuis 2010 dans son centre de formation situé à Pleyber-Christ."
+        }
+
+        """
+        Even after 10 requests for a POI in the WIKI_ES
+        we should not observe any call to the Wikipedia
+        API
+        """
+        for i in range(10):
+            response = client.get(
+                url=f'http://localhost/v1/pois/{basket_ball}?lang=fr',
+            )
+
+        assert len(rsps.calls) == 0


### PR DESCRIPTION
Our intern elastic contains enough POI information to bypass the Wikipedia API.
If the request language belongs to the (comma separated string) list ES_WIKI_LANG, then we fetch this elastic, otherwise we request the Wikipedia API as we did before.