### PR TITLE
Wiki Rate Limiter

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,8 @@ tzwhere = "*"
 babel = "*"
 pybreaker = "*"
 osm-humanized-opening-hours = "==0.6.2"
+redis = "*"
+python-redis-rate-limit = "*"
 lark-parser = "<0.6"
 
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,20 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "415f136026f9d083ddb8c0df9b96d51fdb741e47c92af2e6c4a75f103659edc0"
+            "sha256": "f42bb7c5536c4f0a261e2343468a3551e48e63823f0862dff9c69b69d4d10d58"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.3",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.8.0-53-generic",
+            "platform_system": "Linux",
+            "platform_version": "#56~16.04.1-Ubuntu SMP Tue May 16 01:18:56 UTC 2017",
+            "python_full_version": "3.6.3",
+            "python_version": "3.6",
+            "sys_platform": "linux"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -102,6 +115,12 @@
             "index": "pypi",
             "version": "==0.4.4"
         },
+        "python-redis-rate-limit": {
+            "hashes": [
+                "sha256:f3e9ef020e73793d9b5b109c57615effaf589106606fa2b008e2d6e6607dd4aa"
+            ],
+            "version": "==0.0.6"
+        },
         "pytz": {
             "hashes": [
                 "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
@@ -125,6 +144,13 @@
             ],
             "version": "==3.13"
         },
+        "redis": {
+            "hashes": [
+                "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
+                "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
+            ],
+            "version": "==2.10.6"
+        },
         "requests": {
             "hashes": [
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
@@ -135,18 +161,18 @@
         },
         "shapely": {
             "hashes": [
-                "sha256:0378964902f89b8dbc332e5bdfa08e0bc2f7ab39fecaeb17fbb2a7699a44fe71",
-                "sha256:34e7c6f41fb27906ccdf2514ee44a5774b90b39a256b6511a6a57d11ffe64999",
                 "sha256:3ca69d4b12e2b05b549465822744b6a3a1095d8488cc27b2728a06d3c07d0eee",
-                "sha256:3e9388f29bd81fcd4fa5c35125e1fbd4975ee36971a87a90c093f032d0e9de24",
-                "sha256:3ef28e3f20a1c37f5b99ea8cf8dcb58e2f1a8762d65ed2d21fd92bf1d4811182",
-                "sha256:523c94403047eb6cacd7fc1863ebef06e26c04d8a4e7f8f182d49cd206fe787e",
-                "sha256:5d22a1a705c2f70f61ccadc696e33d922c1a92e00df8e1d58a6ade14dd7e3b4f",
                 "sha256:714b6680215554731389a1bbdae4cec61741aa4726921fa2b2b96a6f578a2534",
-                "sha256:7dfe1528650c3f0dc82f41a74cf4f72018288db9bfb75dcd08f6f04233ec7e78",
+                "sha256:5d22a1a705c2f70f61ccadc696e33d922c1a92e00df8e1d58a6ade14dd7e3b4f",
+                "sha256:34e7c6f41fb27906ccdf2514ee44a5774b90b39a256b6511a6a57d11ffe64999",
+                "sha256:3e9388f29bd81fcd4fa5c35125e1fbd4975ee36971a87a90c093f032d0e9de24",
+                "sha256:0378964902f89b8dbc332e5bdfa08e0bc2f7ab39fecaeb17fbb2a7699a44fe71",
+                "sha256:523c94403047eb6cacd7fc1863ebef06e26c04d8a4e7f8f182d49cd206fe787e",
                 "sha256:ba58b21b9cf3c33725f7f530febff9ed6a6846f9d0bf8a120fc74683ff919f89",
-                "sha256:c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f",
-                "sha256:ebb4d2bee7fac3f6c891fcdafaa17f72ab9c6480f6d00de0b2dc9a5137dfe342"
+                "sha256:ebb4d2bee7fac3f6c891fcdafaa17f72ab9c6480f6d00de0b2dc9a5137dfe342",
+                "sha256:7dfe1528650c3f0dc82f41a74cf4f72018288db9bfb75dcd08f6f04233ec7e78",
+                "sha256:3ef28e3f20a1c37f5b99ea8cf8dcb58e2f1a8762d65ed2d21fd92bf1d4811182",
+                "sha256:c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f"
             ],
             "version": "==1.6.4.post2"
         },
@@ -290,8 +316,8 @@
         },
         "parso": {
             "hashes": [
-                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
-                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
+                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24",
+                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2"
             ],
             "version": "==0.3.1"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f42bb7c5536c4f0a261e2343468a3551e48e63823f0862dff9c69b69d4d10d58"
+            "sha256": "cf17389dd48c3dcb04b5117ed6ce2c4fb422b2f4412b26199b0bb93bf8282f54"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -33,7 +33,6 @@
             "hashes": [
                 "sha256:9158cbdc0449751f0efbc98800546c1cd212f1ff6f8b2a11d2f9df4fcf943110"
             ],
-            "index": "pypi",
             "version": "==0.5.40"
         },
         "babel": {
@@ -41,20 +40,19 @@
                 "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
                 "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
             ],
-            "index": "pypi",
             "version": "==2.6.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0",
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
             ],
             "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
         },
@@ -70,7 +68,6 @@
                 "sha256:bb8f9a365ba6650d599428538c8aed42033264661d8f7d353da59d5892305f72",
                 "sha256:fead47ebfcaabd1c53dbfc21403eb99ac207eef76de8002fe11a1c8ec9589ce2"
             ],
-            "index": "pypi",
             "version": "==2.4.1"
         },
         "idna": {
@@ -91,7 +88,6 @@
             "hashes": [
                 "sha256:2074f2cda9303167f97da0157eefa6fdf9c0b8c7786d4a24e86c65319b34c0df"
             ],
-            "index": "pypi",
             "version": "==0.5.6"
         },
         "markupsafe": {
@@ -102,17 +98,15 @@
         },
         "osm-humanized-opening-hours": {
             "hashes": [
-                "sha256:0bf6eac962fda54e73260d400ece72d84b857150f6bf6b839b514075b3641120",
-                "sha256:327e1db0f87bb8242901b977236e6572dc75746547f6196f1bf4d442796dbe72"
+                "sha256:327e1db0f87bb8242901b977236e6572dc75746547f6196f1bf4d442796dbe72",
+                "sha256:0bf6eac962fda54e73260d400ece72d84b857150f6bf6b839b514075b3641120"
             ],
-            "index": "pypi",
             "version": "==0.6.2"
         },
         "pybreaker": {
             "hashes": [
                 "sha256:c034de4e8d0501bda05dcab21e08f43a4956cf59c1605c8b8d1504ad790d5aa9"
             ],
-            "index": "pypi",
             "version": "==0.4.4"
         },
         "python-redis-rate-limit": {
@@ -130,17 +124,17 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
                 "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
                 "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
             ],
             "version": "==3.13"
         },
@@ -156,7 +150,6 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "index": "pypi",
             "version": "==2.19.1"
         },
         "shapely": {
@@ -178,8 +171,8 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
         },
@@ -187,20 +180,19 @@
             "hashes": [
                 "sha256:b9a056e60f6ad5d44e7bc9d397ae683ea4bcd81f812ab6bbdfaad3d9984fcf19"
             ],
-            "index": "pypi",
             "version": "==3.0.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
             ],
             "version": "==1.23"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b",
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
             ],
             "version": "==0.14.1"
         },
@@ -215,8 +207,8 @@
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6",
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585"
             ],
             "version": "==1.1.5"
         },
@@ -236,15 +228,15 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0",
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
             ],
             "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
         },
@@ -264,10 +256,9 @@
         },
         "freezegun": {
             "hashes": [
-                "sha256:703caac155dcaad61f78de4cb0666dca778d854dfb90b3699930adee0559a622",
-                "sha256:94c59d69bb99c9ec3ca5a3adb41930d3ea09d2a9756c23a02d89fa75646e78dd"
+                "sha256:94c59d69bb99c9ec3ca5a3adb41930d3ea09d2a9756c23a02d89fa75646e78dd",
+                "sha256:703caac155dcaad61f78de4cb0666dca778d854dfb90b3699930adee0559a622"
             ],
-            "index": "pypi",
             "version": "==0.3.10"
         },
         "idna": {
@@ -282,7 +273,6 @@
                 "sha256:a0c96853549b246991046f32d19db7140f5b1a644cc31f0dc1edc86713b7676f",
                 "sha256:eca537aa61592aca2fef4adea12af8e42f5c335004dfa80c78caf80e8b525e5c"
             ],
-            "index": "pypi",
             "version": "==6.4.0"
         },
         "ipython-genutils": {
@@ -294,8 +284,8 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1",
-                "sha256:c254b135fb39ad76e78d4d8f92765ebc9bf92cbc76f49e97ade1d5f5121e1f6f"
+                "sha256:c254b135fb39ad76e78d4d8f92765ebc9bf92cbc76f49e97ade1d5f5121e1f6f",
+                "sha256:b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1"
             ],
             "version": "==0.12.1"
         },
@@ -303,14 +293,13 @@
             "hashes": [
                 "sha256:238ed21dd56d070dfd23e78663ecdb8ff49a7c24f5fa1c370e4fb95476f5b1ae"
             ],
-            "index": "pypi",
             "version": "==0.0.3"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0",
                 "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8"
             ],
             "version": "==4.2.0"
         },
@@ -323,46 +312,46 @@
         },
         "pexpect": {
             "hashes": [
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b",
+                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba"
             ],
             "markers": "sys_platform != 'win32'",
             "version": "==4.6.0"
         },
         "pickleshare": {
             "hashes": [
-                "sha256:84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b",
-                "sha256:c9a2541f25aeabc070f12f452e1f2a8eae2abd51e1cd19e8430402bdf4c1d8b5"
+                "sha256:c9a2541f25aeabc070f12f452e1f2a8eae2abd51e1cd19e8430402bdf4c1d8b5",
+                "sha256:84a9257227dfdd6fe1b4be1319096c20eb85ff1e82c7932f36efccfe1b09737b"
             ],
             "version": "==0.7.4"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
                 "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5",
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
             ],
             "version": "==0.6.0"
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381",
                 "sha256:3f473ae040ddaa52b52f97f6b4a493cfa9f5920c255a12dc56a7d34397a398a4",
+                "sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381",
                 "sha256:858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917"
             ],
             "version": "==1.0.15"
         },
         "ptyprocess": {
             "hashes": [
-                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
-                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f",
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"
             ],
             "version": "==0.6.0"
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e",
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7"
             ],
             "version": "==1.5.4"
         },
@@ -375,10 +364,9 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
-                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
+                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d",
+                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752"
             ],
-            "index": "pypi",
             "version": "==3.6.3"
         },
         "python-dateutil": {
@@ -393,15 +381,13 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "index": "pypi",
             "version": "==2.19.1"
         },
         "responses": {
             "hashes": [
-                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9",
-                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3"
+                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3",
+                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9"
             ],
-            "index": "pypi",
             "version": "==0.9.0"
         },
         "simplegeneric": {
@@ -412,29 +398,29 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
         },
         "traitlets": {
             "hashes": [
-                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
-                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
+                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9",
+                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835"
             ],
             "version": "==4.3.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
             ],
             "version": "==1.23"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
-                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c",
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"
             ],
             "version": "==0.1.7"
         }

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -5,7 +5,58 @@ from .base import BaseBlock, BlocksValidator
 from requests.exceptions import HTTPError, RequestException, Timeout
 import pybreaker
 from elasticsearch import Elasticsearch
+from redis import ConnectionPool
 
+from redis_rate_limit import RateLimiter, TooManyRequests
+
+class HTTPError40X(HTTPError):
+    pass
+
+class WikipediaLimiter:
+    _limiter = None
+    _redis_url = None
+
+    @classmethod
+    def init_limiter(cls):
+        from app import settings
+
+        cls._redis_url = settings['WIKI_API_REDIS_URL']
+
+        if cls._redis_url is not None:
+            """
+            If a redis url has been provided to Idunn,
+            then we use the corresponding redis
+            service in the rate limiter.
+            """
+            url = cls._redis_url.split(":")[0]
+            port = cls._redis_url.split(":")[1]
+
+            cls._limiter = RateLimiter(
+                resource='WikipediaAPI',
+                max_requests=settings['WIKI_API_RL_MAX_CALLS'],
+                expire=settings['WIKI_API_RL_PERIOD'],
+                redis_pool=ConnectionPool(host=url, port=port, db=0)
+            )
+
+    @classmethod
+    def request(cls, f):
+        def wrapper(*args, **kwargs):
+            if cls._limiter is None:
+                cls.init_limiter()
+            if cls._redis_url is not None:
+                """
+                We use the RateLimiter since
+                the redis service url has been provided
+                """
+                with cls._limiter.limit(client="Idunn"):
+                    return f(*args, **kwargs)
+            else:
+                """
+                No redis service has been set, so we
+                bypass the "redis-based" rate limiter
+                """
+                return f(*args, **kwargs)
+        return wrapper
 
 class WikipediaBreaker:
     _breaker = None
@@ -16,7 +67,8 @@ class WikipediaBreaker:
         cls._breaker = pybreaker.CircuitBreaker(
                 fail_max = settings['WIKI_API_CIRCUIT_MAXFAIL'],
                 reset_timeout = settings['WIKI_API_CIRCUIT_TIMEOUT'],
-                exclude = [HTTPError40X])
+                exclude = [HTTPError40X]
+        )
 
     @classmethod
     def get_breaker(cls):
@@ -27,9 +79,11 @@ class WikipediaBreaker:
     @classmethod
     def handle_requests_error(cls, f):
         def wrapper(*args, **kwargs):
+
             breaker = cls.get_breaker()
+
             try:
-                return breaker(f)(*args, **kwargs)
+                return WikipediaLimiter.request(breaker(f))(*args, **kwargs)
             except pybreaker.CircuitBreakerError:
                 logging.info("Got CircuitBreakerError in {}".format(f.__name__), exc_info=True)
             except HTTPError:
@@ -38,11 +92,9 @@ class WikipediaBreaker:
                 logging.warning("External API timed out in {}".format(f.__name__), exc_info=True)
             except RequestException:
                 logging.error("Got Request exception in {}".format(f.__name__), exc_info=True)
+            except TooManyRequests:
+                logging.info("Got TooManyRequests{}".format(f.__name__), exc_info=True)
         return wrapper
-
-
-class HTTPError40X(HTTPError):
-    pass
 
 class WikipediaSession:
     _session = None
@@ -188,7 +240,7 @@ class WikipediaBlock(BaseBlock):
                         """
                         return None
                 except WikiUndefinedException:
-                    logging.warning("WIKI_ES variable has not been set: call to Wikipedia")
+                    logging.info("WIKI_ES variable has not been set: call to Wikipedia")
 
         wikipedia_value = es_poi.get("properties", {}).get("wikipedia")
         wiki_title = None

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -28,25 +28,19 @@ class WikipediaLimiter:
                 then we use the corresponding redis
                 service in the rate limiter.
                 """
-                ip, separator, port = redis_url.rpartition(':')
-                try:
-                    assert ip
-                    assert port
+                ip, port = redis_url.split(":")
 
-                    max_calls = int(settings['WIKI_API_RL_MAX_CALLS'])
-                    redis_period = int(settings['WIKI_API_RL_PERIOD'])
-                    redis_db = settings['WIKI_API_REDIS_DB']
-                    redis_timeout = int(settings['WIKI_REDIS_TIMEOUT'])
+                max_calls = int(settings['WIKI_API_RL_MAX_CALLS'])
+                redis_period = int(settings['WIKI_API_RL_PERIOD'])
+                redis_db = settings['WIKI_API_REDIS_DB']
+                redis_timeout = int(settings['WIKI_REDIS_TIMEOUT'])
 
-                    cls._limiter = RateLimiter(
-                        resource='WikipediaAPI',
-                        max_requests=max_calls,
-                        expire=redis_period,
-                        redis_pool=ConnectionPool(host=ip, port=port, db=redis_db, socket_timeout=redis_timeout)
-                    )
-                except AssertionError:
-                    cls._limiter = False
-                    logging.info("Redis URL provided is not valid", exc_info=True)
+                cls._limiter = RateLimiter(
+                    resource='WikipediaAPI',
+                    max_requests=max_calls,
+                    expire=redis_period,
+                    redis_pool=ConnectionPool(host=ip, port=port, db=redis_db, socket_timeout=redis_timeout)
+                )
             else:
                 logging.info("No Redis URL has been provided: rate limiter not started", exc_info=True)
                 cls._limiter = False

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -18,3 +18,5 @@ WIKI_API_RL_MAX_CALLS: 100 # Max number of external calls allowed by the rate li
 WIKI_API_RL_PERIOD: 1 # Duration (in seconds) of the period where no more than the max number of external calls are expected
 
 WIKI_API_REDIS_URL: # URL of the Redis service used by the rate limiter of the Wikipedia API calls
+
+WIKI_API_REDIS_DB: 0

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -12,3 +12,9 @@ WIKI_API_CIRCUIT_TIMEOUT: 120
 WIKI_API_CIRCUIT_MAXFAIL: 50
 
 ES_WIKI_LANG: "de,en,es,fr,it" # the (comma separated) list of languages existing in the WIKI_ES
+
+WIKI_API_RL_MAX_CALLS: 100 # Max number of external calls allowed by the rate limiter
+
+WIKI_API_RL_PERIOD: 1 # Duration (in seconds) of the period where no more than the max number of external calls are expected
+
+WIKI_API_REDIS_URL: # URL of the Redis service used by the rate limiter of the Wikipedia API calls

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -20,3 +20,5 @@ WIKI_API_RL_PERIOD: 1 # Duration (in seconds) of the period where no more than t
 WIKI_API_REDIS_URL: # URL of the Redis service used by the rate limiter of the Wikipedia API calls
 
 WIKI_API_REDIS_DB: 0
+
+WIKI_REDIS_TIMEOUT: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,11 @@ import pytest
 import responses
 import re
 from elasticsearch import Elasticsearch
-
-from app import settings
+from app import app, settings
+from idunn.utils.settings import SettingsComponent
+from idunn.blocks.wikipedia import HTTPError40X
+from idunn.blocks.wikipedia import WikipediaLimiter
+import time
 
 
 @pytest.fixture(scope='session')
@@ -72,3 +75,13 @@ def mock_external_requests():
                  re.compile('^https://.*\.wikipedia.org/'),
                  status=404)
         yield
+
+@pytest.fixture(scope='session')
+def redis(docker_services):
+    """Ensure that Redis is up and responsive."""
+    docker_services.start('wiki_redis')
+    port = docker_services.port_for("wiki_redis", 6379)
+
+    url = f'{docker_services.docker_ip}:{port}'
+
+    return url

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -9,4 +9,9 @@ services:
   wiki_es:
     image: elasticsearch:2-alpine
     ports:
-        - "9200"
+    - "9200"
+
+  wiki_redis:
+    image: redis:3.2-alpine
+    ports:
+    - "6379"

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,82 @@
+import responses
+import pytest
+import re
+from freezegun import freeze_time
+from app import app, settings
+from apistar.test import TestClient
+from idunn.blocks.wikipedia import WikipediaLimiter
+from time import sleep
+
+from .test_full import fake_all_blocks
+
+@pytest.fixture(scope="function")
+def limiter_test(redis):
+    """
+    We define here settings specific to tests
+    for the rate limiter in order to avoid
+    any waste of time
+    """
+    settings._settings['WIKI_API_RL_PERIOD'] = 5
+    settings._settings['WIKI_API_RL_MAX_CALLS'] = 3
+    settings._settings['WIKI_API_REDIS_URL'] = redis
+    WikipediaLimiter._limiter = None
+    wiki_limiter = WikipediaLimiter.init_limiter()
+    yield
+    settings._settings['WIKI_API_RL_PERIOD'] = 100
+    settings._settings['WIKI_API_RL_MAX_CALLS'] = 1
+    settings._settings['WIKI_API_REDIS_URL'] = None
+    WikipediaLimiter._limiter = None
+
+def test_rate_limiter_with_redis(fake_all_blocks, limiter_test):
+    """
+    Test that Idunn stops external requests when
+    we are above the max rate
+    """
+    client = TestClient(app)
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add('GET',
+             re.compile('^https://.*\.wikipedia.org/'),
+             status=200,
+             json={"test": "test"}
+        )
+        """
+        We mock 10 calls to wikipedia while the max number
+        of calls is 3, so we test that after 3 calls
+        no more calls are done
+        """
+
+        for i in range(10):
+            response = client.get(
+               url=f'http://localhost/v1/pois/{fake_all_blocks}?lang=es',
+            )
+
+        assert len(rsps.calls) == 3
+
+        """
+        Because of the fail of the last call,
+        no wikipedia block should be in the
+        answer
+        """
+        resp = response.json()
+        assert all(b['type'] != "wikipedia" for b in resp['blocks'])
+
+def test_rate_limiter_without_redis(fake_all_blocks):
+    """
+    Test that Idunn doesn't stop external requests when
+    no redis has been set: 10 requests to Idunn should
+    generate 10 requests to Wikipedia API
+    """
+    client = TestClient(app)
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add('GET',
+             re.compile('^https://.*\.wikipedia.org/'),
+             status=200,
+             json={"test": "test"}
+        )
+
+        for i in range(10):
+            response = client.get(
+               url=f'http://localhost/v1/pois/{fake_all_blocks}?lang=es',
+            )
+
+        assert len(rsps.calls) == 10

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,82 +1,252 @@
 import responses
 import pytest
 import re
+from time import sleep
 from freezegun import freeze_time
 from app import app, settings
 from apistar.test import TestClient
 from idunn.blocks.wikipedia import WikipediaLimiter
-from time import sleep
 
-from .test_full import fake_all_blocks
+from .test_api import louvre_museum
+
 
 @pytest.fixture(scope="function")
-def limiter_test(redis):
+def limiter_test_normal(redis):
     """
-    We define here settings specific to tests
-    for the rate limiter in order to avoid
-    any waste of time
+    We define here settings specific to tests.
+    We define low max calls limits to avoid
+    too large number of requests made
     """
+    temp_period = settings._settings['WIKI_API_RL_PERIOD']
+    temp_maxcalls = settings._settings['WIKI_API_RL_MAX_CALLS']
+
     settings._settings['WIKI_API_RL_PERIOD'] = 5
-    settings._settings['WIKI_API_RL_MAX_CALLS'] = 3
+    # 2 wiki calls are made per request, so 6 max_calls mean 3 max wiki calls
+    settings._settings['WIKI_API_RL_MAX_CALLS'] = 6
     settings._settings['WIKI_API_REDIS_URL'] = redis
     WikipediaLimiter._limiter = None
-    wiki_limiter = WikipediaLimiter.init_limiter()
     yield
-    settings._settings['WIKI_API_RL_PERIOD'] = 100
-    settings._settings['WIKI_API_RL_MAX_CALLS'] = 1
+    settings._settings['WIKI_API_RL_PERIOD'] = temp_period
+    settings._settings['WIKI_API_RL_MAX_CALLS'] = temp_maxcalls
     settings._settings['WIKI_API_REDIS_URL'] = None
     WikipediaLimiter._limiter = None
 
-def test_rate_limiter_with_redis(fake_all_blocks, limiter_test):
+@pytest.fixture(scope="function")
+def limiter_test_interruption(redis):
+    """
+    In the 'Redis interruption' test below
+    we made more requests than the limits
+    allowed by the fixture 'limiter_test_normal'
+    So we need another specific fixture.
+    """
+    settings._settings['WIKI_API_REDIS_URL'] = redis
+    WikipediaLimiter._limiter = None
+    yield
+    settings._settings['WIKI_API_REDIS_URL'] = None
+    WikipediaLimiter._limiter = None
+
+@pytest.fixture(scope='module', autouse=True)
+def mock_wikipedia(redis):
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            responses.GET,
+            'https://fr.wikipedia.org/w/api.php',
+            json={
+                "query": {
+                    "pages": [{
+                        "pageid": 69682,
+                        "ns": 0,
+                        "title": "Musée du Louvre",
+                        "langlinks": [{"lang": "es", "title": "Museo del Louvre"}]
+                    }]
+                }
+            }
+        )
+
+        rsps.add(
+            responses.GET,
+            'https://es.wikipedia.org/api/rest_v1/page/summary/Museo%20del%20Louvre',
+            json={  # This is a subset of the real response
+                "type": "standard",
+                "title": "Museo del Louvre",
+                "displaytitle": "Museo del Louvre",
+                "content_urls": {
+                    "desktop": {
+                        "page": "https://es.wikipedia.org/wiki/Museo_del_Louvre",
+                        "revisions": "https://es.wikipedia.org/wiki/Museo_del_Louvre?action=history",
+                        "edit": "https://es.wikipedia.org/wiki/Museo_del_Louvre?action=edit",
+                        "talk": "https://es.wikipedia.org/wiki/Discusión:Museo_del_Louvre"
+                    },
+                    "mobile": {
+                        "page": "https://es.m.wikipedia.org/wiki/Museo_del_Louvre",
+                        "revisions": "https://es.m.wikipedia.org/wiki/Special:History/Museo_del_Louvre",
+                        "edit": "https://es.m.wikipedia.org/wiki/Museo_del_Louvre?action=edit",
+                        "talk": "https://es.m.wikipedia.org/wiki/Discusión:Museo_del_Louvre"
+                    },
+                },
+                "api_urls": {
+                    "summary": "https://es.wikipedia.org/api/rest_v1/page/summary/Museo_del_Louvre",
+                    "metadata": "https://es.wikipedia.org/api/rest_v1/page/metadata/Museo_del_Louvre",
+                    "references": "https://es.wikipedia.org/api/rest_v1/page/references/Museo_del_Louvre",
+                    "media": "https://es.wikipedia.org/api/rest_v1/page/media/Museo_del_Louvre",
+                    "edit_html": "https://es.wikipedia.org/api/rest_v1/page/html/Museo_del_Louvre",
+                    "talk_page_html": "https://es.wikipedia.org/api/rest_v1/page/html/Discusión:Museo_del_Louvre"
+                },
+                "extract": "El Museo del Louvre es el museo nacional de Francia ...",
+                "extract_html": "<p>El <b>Museo del Louvre</b> es el museo nacional de Francia consagrado...</p>"
+            }
+        )
+        yield rsps
+
+
+def test_rate_limiter_with_redis(louvre_museum, limiter_test_normal, mock_wikipedia):
     """
     Test that Idunn stops external requests when
     we are above the max rate
+
+    We mock 5 calls to wikipedia while the max number
+    of calls is 3*2, so we test that after 3 calls
+    no more calls are done
     """
     client = TestClient(app)
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
-        rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
-             status=200,
-             json={"test": "test"}
+
+    for i in range(3):
+        response = client.get(
+           url=f'http://localhost/v1/pois/{louvre_museum}?lang=es',
         )
-        """
-        We mock 10 calls to wikipedia while the max number
-        of calls is 3, so we test that after 3 calls
-        no more calls are done
-        """
-
-        for i in range(10):
-            response = client.get(
-               url=f'http://localhost/v1/pois/{fake_all_blocks}?lang=es',
-            )
-
-        assert len(rsps.calls) == 3
-
-        """
-        Because of the fail of the last call,
-        no wikipedia block should be in the
-        answer
-        """
         resp = response.json()
-        assert all(b['type'] != "wikipedia" for b in resp['blocks'])
+        assert any(b['type'] == "wikipedia" for b in resp['blocks'][2].get('blocks'))
 
-def test_rate_limiter_without_redis(fake_all_blocks):
+    for i in range(2):
+        response = client.get(
+            url=f'http://localhost/v1/pois/{louvre_museum}?lang=es',
+        )
+        resp = response.json()
+        assert all(b['type'] != "wikipedia" for b in resp['blocks'][2].get('blocks'))
+
+    assert len(mock_wikipedia.calls) == 6
+
+def test_rate_limiter_without_redis(louvre_museum):
     """
     Test that Idunn doesn't stop external requests when
     no redis has been set: 10 requests to Idunn should
     generate 10 requests to Wikipedia API
     """
     client = TestClient(app)
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+
+    with responses.RequestsMock() as rsps:
         rsps.add('GET',
              re.compile('^https://.*\.wikipedia.org/'),
              status=200,
              json={"test": "test"}
         )
-
         for i in range(10):
             response = client.get(
-               url=f'http://localhost/v1/pois/{fake_all_blocks}?lang=es',
+               url=f'http://localhost/v1/pois/{louvre_museum}?lang=es',
             )
 
         assert len(rsps.calls) == 10
+
+
+def restart_wiki_redis(docker_services):
+    """
+    Because docker services ports are
+    dynamically chosen when the service starts
+    we have to get the new port of the service.
+    """
+    docker_services.start('wiki_redis')
+    """
+    we have to remove the previous port of the
+    redis service which has been stored in the dict '_services'
+    before to get the new one
+    """
+    del docker_services._services['wiki_redis']
+    port = docker_services.port_for("wiki_redis", 6379)
+    url = f'{docker_services.docker_ip}:{port}'
+    settings._settings['WIKI_API_REDIS_URL'] = url
+    WikipediaLimiter._limiter = None
+
+@freeze_time("2018-06-14 8:30:00", tz_offset=2)
+def test_rate_limiter_with_redis_interruption(louvre_museum, docker_services, redis, limiter_test_interruption):
+    """
+    Test that Idunn isn't impacted by any Redis interruption:
+    If Redis service stops then the wikipedia block should not be returned.
+    And when Redis restarts the wikipedia block should be returned again
+
+    This test has 3 steps:
+        * A: redis is up: we have the wiki block
+        * B: redis is down: no wiki block
+        * C: redis is up again: we have the wiki block again
+    """
+    client = TestClient(app)
+
+    response = client.get(
+        url=f'http://localhost/v1/pois/{louvre_museum}?lang=es',
+    )
+    assert response.status_code == 200
+    resp = response.json()
+
+    """
+    A/
+
+    Before Redis interruption we check the answer is correct
+    """
+    assert resp['id'] == 'osm:relation:7515426'
+    assert resp['name'] == "Museo del Louvre"
+    assert resp['local_name'] == "Musée du Louvre"
+    assert resp['class_name'] == 'museum'
+    assert resp['subclass_name'] == 'museum'
+    assert resp['blocks'][2].get('blocks')[0] == {
+        'type': 'wikipedia',
+        'url': 'https://es.wikipedia.org/wiki/Museo_del_Louvre',
+        'title': 'Museo del Louvre',
+        'description': 'El Museo del Louvre es el museo nacional de Francia ...'
+    }
+
+    """
+    B/
+
+    We interrupt the Redis service and we make a new Idunn request
+    """
+    docker_services._docker_compose.execute('stop', 'wiki_redis')
+    response = client.get(
+        url=f'http://localhost/v1/pois/{louvre_museum}?lang=es',
+    )
+    assert response.status_code == 200
+    """
+    The wikipedia block should not be returned:
+    we check we have all the information, except
+    the wikipedia block.
+    """
+    resp = response.json()
+    assert resp['id'] == 'osm:relation:7515426'
+    assert resp['name'] == "Museo del Louvre"
+    assert resp['local_name'] == "Musée du Louvre"
+    assert resp['class_name'] == 'museum'
+    assert resp['subclass_name'] == 'museum'
+    assert all(b['type'] != "wikipedia" for b in resp['blocks'][2].get('blocks'))
+
+    """
+    C/
+
+    When Redis service restarts the wikipedia block
+    should be returned again.
+    """
+    restart_wiki_redis(docker_services)
+    response = client.get(
+        url=f'http://localhost/v1/pois/{louvre_museum}?lang=es',
+    )
+    assert response.status_code == 200
+    resp = response.json()
+
+    assert resp['id'] == 'osm:relation:7515426'
+    assert resp['name'] == "Museo del Louvre"
+    assert resp['local_name'] == "Musée du Louvre"
+    assert resp['class_name'] == 'museum'
+    assert resp['subclass_name'] == 'museum'
+    assert resp['blocks'][2].get('blocks')[0] == {
+        'type': 'wikipedia',
+        'url': 'https://es.wikipedia.org/wiki/Museo_del_Louvre',
+        'title': 'Museo del Louvre',
+        'description': 'El Museo del Louvre es el museo nacional de Francia ...'
+    }


### PR DESCRIPTION
Because of standard API usage limitations, Idunn cannot make more than 200 requests per second to Wikipedia API.
This PR proposes a rate limiter upon a Redis service.

To activate the limiter you have to define the variable "WIKI_API_REDIS_URL".
If this variable is not set then Idunn doesn't limit its external requests number.