### PR TITLE
Wiki ES timeout

### DIFF
--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -209,7 +209,7 @@ class WikidataConnector:
                 }
             ).get('hits', {}).get('hits', [])
         except ConnectionError:
-            logging.warning("Wiki ES not available: exception raised in {}".format(f.__name__), exc_info=True)
+            logging.warning("Wiki ES not available: connection exception raised", exc_info=True)
             return None
 
         if len(resp) == 0:

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -4,7 +4,7 @@ from apistar import validators
 from .base import BaseBlock, BlocksValidator
 from requests.exceptions import HTTPError, RequestException, Timeout
 import pybreaker
-from redis import ConnectionPool, ConnectionError, TimeoutError
+from redis import ConnectionPool, ConnectionError as RedisConnectionError, TimeoutError
 from elasticsearch import Elasticsearch, ElasticsearchException, RequestError, ConnectionTimeout, ConnectionError
 
 from redis_rate_limit import RateLimiter, TooManyRequests
@@ -101,7 +101,7 @@ class WikipediaBreaker:
                 logging.error("Got Request exception in {}".format(f.__name__), exc_info=True)
             except TooManyRequests:
                 logging.info("Got TooManyRequests{}".format(f.__name__), exc_info=True)
-            except ConnectionError:
+            except RedisConnectionError:
                 logging.info("Got redis ConnectionError{}".format(f.__name__), exc_info=True)
             except TimeoutError:
                 logging.info("Got redis TimeoutError{}".format(f.__name__), exc_info=True)

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -198,7 +198,7 @@ class WikidataConnector:
                 cls._wiki_es = Elasticsearch(
                         wiki_es,
                         max_retries=wiki_es_max_retries,
-                        request_timeout=wiki_es_timeout
+                        timeout=wiki_es_timeout
                 )
 
     @classmethod

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -187,11 +187,19 @@ class WikidataConnector:
     def init_wiki_es(cls):
         if cls._wiki_es is None:
             from app import settings
+
             wiki_es = settings.get('WIKI_ES')
+            wiki_es_max_retries = settings.get('WIKI_ES_MAX_RETRIES')
+            wiki_es_timeout = settings.get('WIKI_ES_TIMEOUT')
+
             if wiki_es is None:
                 raise WikiUndefinedException
             else:
-                cls._wiki_es = Elasticsearch(wiki_es)
+                cls._wiki_es = Elasticsearch(
+                        wiki_es,
+                        max_retries=wiki_es_max_retries,
+                        request_timeout=wiki_es_timeout
+                )
 
     @classmethod
     def get_wiki_info(cls, wikidata_id, lang, wiki_index):

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -5,7 +5,7 @@ from .base import BaseBlock, BlocksValidator
 from requests.exceptions import HTTPError, RequestException, Timeout
 import pybreaker
 from redis import ConnectionPool, ConnectionError as RedisConnectionError, TimeoutError
-from elasticsearch import Elasticsearch, ElasticsearchException, RequestError, ConnectionTimeout, ConnectionError
+from elasticsearch import Elasticsearch, ConnectionError
 
 from redis_rate_limit import RateLimiter, TooManyRequests
 

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -3,6 +3,10 @@ MIMIR_ES: http://localhost:9200/
 
 WIKI_ES:
 
+WIKI_ES_TIMEOUT: 0.5
+
+WIKI_ES_MAX_RETRIES: 0
+
 WIKI_USER_AGENT: 'Idunn' # Used in requests to external wiki* APIs
 
 DEFAULT_LANGUAGE: 'en' # Fallback when no 'lang' in request

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,36 +25,50 @@ def mimir_es(docker_services):
 def mimir_client(mimir_es):
     return Elasticsearch([mimir_es])
 
+
 @pytest.fixture(scope='session')
 def wiki_es(docker_services):
     """Ensure that ES is up and responsive."""
     docker_services.start('wiki_es')
     port = docker_services.wait_for_service("wiki_es", 9200)
 
-    url = f'http://{docker_services.docker_ip}:{port}'
+    temp_wiki_es = settings._settings['WIKI_ES']
+    temp_es_wiki_lang = settings._settings['ES_WIKI_LANG']
 
+    url = f'http://{docker_services.docker_ip}:{port}'
     settings._settings['WIKI_ES'] = url
     settings._settings['ES_WIKI_LANG'] = 'fr'
+
     return url
+
+    settings._settings['WIKI_ES'] = temp_wiki_es
+    settings._settings['ES_WIKI_LANG'] = temp_es_wiki_lang
 
 @pytest.fixture(scope='session')
 def wiki_client(wiki_es):
     return Elasticsearch([wiki_es])
+
 
 @pytest.fixture(scope='session')
 def wiki_es_ko(docker_services):
     docker_services.start('wiki_es')
     port = docker_services.wait_for_service("wiki_es", 9200)
 
-    url = "1.1.1.1:1234"
+    temp_wiki_es = settings._settings['WIKI_ES']
+    temp_es_wiki_lang = settings._settings['ES_WIKI_LANG']
 
-    settings._settings['WIKI_ES'] = "1.1.1.1:1234"
+    url = "something.invalid:1234"
+    settings._settings['WIKI_ES'] = url
     settings._settings['ES_WIKI_LANG'] = 'fr'
+
     return url
 
+    settings._settings['WIKI_ES'] = temp_wiki_es
+    settings._settings['ES_WIKI_LANG'] = temp_es_wiki_lang
+
 @pytest.fixture(scope='session')
-def wiki_client_ko(wiki_es):
-    return Elasticsearch([wiki_es])
+def wiki_client_ko(wiki_es_ko):
+    return Elasticsearch([wiki_es_ko])
 
 
 @pytest.fixture(scope="session")
@@ -82,6 +96,7 @@ def init_indices(mimir_client, wiki_client):
             }
         }
     )
+
 
 @pytest.fixture(scope="module", autouse=True)
 def mock_external_requests():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,10 +37,25 @@ def wiki_es(docker_services):
     settings._settings['ES_WIKI_LANG'] = 'fr'
     return url
 
-
 @pytest.fixture(scope='session')
 def wiki_client(wiki_es):
     return Elasticsearch([wiki_es])
+
+@pytest.fixture(scope='session')
+def wiki_es_ko(docker_services):
+    docker_services.start('wiki_es')
+    port = docker_services.wait_for_service("wiki_es", 9200)
+
+    url = "1.1.1.1:1234"
+
+    settings._settings['WIKI_ES'] = "1.1.1.1:1234"
+    settings._settings['ES_WIKI_LANG'] = 'fr'
+    return url
+
+@pytest.fixture(scope='session')
+def wiki_client_ko(wiki_es):
+    return Elasticsearch([wiki_es])
+
 
 @pytest.fixture(scope="session")
 def init_indices(mimir_client, wiki_client):

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -10,7 +10,7 @@ from app import app, settings
 from .test_api import load_poi, orsay_museum
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def basket_ball_wiki_es(wiki_client, init_indices):
     """
     fill the elasticsearch WIKI_ES with a POI of basket ball
@@ -33,14 +33,45 @@ def basket_ball(mimir_client, init_indices):
     """
     return load_poi('basket_ball.json', mimir_client)
 
-@pytest.fixture(scope="function")
-def undefine_wiki_es():
-    from idunn.blocks.wikipedia import WikidataConnector
-    WikidataConnector._wiki_es = None
-    wiki_es_ip = settings['WIKI_ES'] # temporary variable to store the ip of WIKI_ES to reset it after the test
-    settings._settings['WIKI_ES'] = None
-    yield
-    settings._settings['WIKI_ES'] = wiki_es_ip # put back the correct ip for next tests
+@freeze_time("2018-06-14 8:30:00", tz_offset=2)
+def test_basket_ball(basket_ball):
+    """
+    Check that the wikipedia block contains the correct
+    information about a POI that is in the WIKI_ES.
+    """
+    client = TestClient(app)
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add('GET',
+             re.compile('^https://.*\.wikipedia.org/'),
+             status=200)
+
+        response = client.get(
+            url=f'http://localhost/v1/pois/{basket_ball}?lang=fr',
+        )
+
+        assert response.status_code == 200
+
+        resp = response.json()
+
+        assert resp['blocks'][2].get('blocks')[0] == {
+            'type': 'wikipedia',
+            'url': 'https://fr.wikipedia.org/wiki/Pleyber-Christ_Basket_Club',
+            'title': 'Pleyber-Christ Basket Club',
+            'description': "Le Pleyber-Christ Basket Club est un club français de basket-ball dont la section senior féminine a accédé jusqu'au championnat professionnel de Ligue 2 (2e division nationale), performance remarquée pour un village de 3000 habitants. Le club est basé dans la ville de Pleyber-Christ. Il accueille aussi de jeunes joueuses depuis 2010 dans son centre de formation situé à Pleyber-Christ."
+        }
+
+        """
+        Even after 10 requests for a POI in the WIKI_ES
+        we should not observe any call to the Wikipedia
+        API
+        """
+        for i in range(10):
+            response = client.get(
+                url=f'http://localhost/v1/pois/{basket_ball}?lang=fr',
+            )
+
+        assert len(rsps.calls) == 0
+
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
 def test_WIKI_ES_KO(wiki_client_ko, orsay_museum):
@@ -105,8 +136,16 @@ def test_WIKI_ES_KO(wiki_client_ko, orsay_museum):
         We check that there is no Wikipedia block
         in the answer
         """
-        assert all(b['type'] != "wikipedia" for b in resp['blocks'])
+        assert all(b['type'] != "wikipedia" for b in resp['blocks'][2].get('blocks'))
 
+@pytest.fixture(scope="function")
+def undefine_wiki_es():
+    from idunn.blocks.wikipedia import WikidataConnector
+    WikidataConnector._wiki_es = None
+    wiki_es_ip = settings['WIKI_ES'] # temporary variable to store the ip of WIKI_ES to reset it after the test
+    settings._settings['WIKI_ES'] = None
+    yield
+    settings._settings['WIKI_ES'] = wiki_es_ip # put back the correct ip for next tests
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
 def test_undefined_WIKI_ES(basket_ball, undefine_wiki_es):
@@ -129,7 +168,7 @@ def test_undefined_WIKI_ES(basket_ball, undefine_wiki_es):
         assert len(rsps.calls) == 10
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
-def test_POI_not_in_WIKI_ES(orsay_museum, basket_ball_wiki_es):
+def test_POI_not_in_WIKI_ES(orsay_museum):
     """
     Test that when the POI requested is not in WIKI_ES
     no call to Wikipedia is observed
@@ -193,7 +232,7 @@ def test_POI_not_in_WIKI_ES(orsay_museum, basket_ball_wiki_es):
 
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
-def test_no_lang_WIKI_ES(basket_ball, basket_ball_wiki_es):
+def test_no_lang_WIKI_ES(basket_ball):
     """
     Test that when we don't have the lang available in the index
     we call Wikipedia API
@@ -214,41 +253,3 @@ def test_no_lang_WIKI_ES(basket_ball, basket_ball_wiki_es):
 
         assert len(rsps.calls) == 1
 
-@freeze_time("2018-06-14 8:30:00", tz_offset=2)
-def test_basket_ball(basket_ball, basket_ball_wiki_es):
-    """
-    Check that the wikipedia block contains the correct
-    information about a POI that is in the WIKI_ES.
-    """
-    client = TestClient(app)
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
-        rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
-             status=200)
-
-        response = client.get(
-            url=f'http://localhost/v1/pois/{basket_ball}?lang=fr',
-        )
-
-        assert response.status_code == 200
-
-        resp = response.json()
-
-        assert resp['blocks'][2].get('blocks')[0] == {
-            'type': 'wikipedia',
-            'url': 'https://fr.wikipedia.org/wiki/Pleyber-Christ_Basket_Club',
-            'title': 'Pleyber-Christ Basket Club',
-            'description': "Le Pleyber-Christ Basket Club est un club français de basket-ball dont la section senior féminine a accédé jusqu'au championnat professionnel de Ligue 2 (2e division nationale), performance remarquée pour un village de 3000 habitants. Le club est basé dans la ville de Pleyber-Christ. Il accueille aussi de jeunes joueuses depuis 2010 dans son centre de formation situé à Pleyber-Christ."
-        }
-
-        """
-        Even after 10 requests for a POI in the WIKI_ES
-        we should not observe any call to the Wikipedia
-        API
-        """
-        for i in range(10):
-            response = client.get(
-                url=f'http://localhost/v1/pois/{basket_ball}?lang=fr',
-            )
-
-        assert len(rsps.calls) == 0

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -108,8 +108,7 @@ def test_WIKI_ES_KO(wiki_client_ko, orsay_museum):
         assert resp.get('blocks')[2].get('blocks')[0].get('blocks') == [
             {
                 "type": "accessibility",
-                "wheelchair": "true",
-                "tactile_paving": "unknown",
+                "wheelchair": "yes",
                 "toilets_wheelchair": "unknown"
             },
             {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+from copy import deepcopy
+from app import settings
+
+@contextmanager
+def override_settings(overrides):
+    """
+    A utility function used by some fixtures to override settings
+    """
+    old_settings = deepcopy(settings._settings)
+    settings._settings.update(overrides)
+    try:
+        yield
+    finally:
+        settings._settings = old_settings


### PR DESCRIPTION
When the Wiki ES service is down we want Idunn continue to deliver the correct information.
In this small patch we catch the 'connectionerror' to avoid the Idunn failure.

+ small test