### PR TITLE
tactile_paving removed

### DIFF
--- a/idunn/blocks/services_and_information.py
+++ b/idunn/blocks/services_and_information.py
@@ -24,12 +24,6 @@ class AccessibilityBlock(BaseBlock):
         raw_wheelchair = properties.get("wheelchair")
         raw_toilets_wheelchair = properties.get("toilets:wheelchair")
 
-        if all(
-            s is None
-            for s in (raw_wheelchair, raw_toilets_wheelchair)
-        ):
-            return None
-
         if raw_wheelchair in ("yes", "designated"):
             wheelchair = cls.STATUS_OK
         elif raw_wheelchair == "limited":

--- a/idunn/blocks/services_and_information.py
+++ b/idunn/blocks/services_and_information.py
@@ -5,15 +5,14 @@ from .base import BaseBlock, BlocksValidator
 class AccessibilityBlock(BaseBlock):
     BLOCK_TYPE = "accessibility"
 
-    STATUS_OK = "true"
-    STATUS_KO = "false"
-    STATUS_LIMITED = "limited"
+    STATUS_OK = "yes"
+    STATUS_KO = "no"
+    STATUS_LIMITED = "partial"
     STATUS_UNKNOWN = "unknown"
 
     wheelchair = validators.String(
         enum=[STATUS_OK, STATUS_KO, STATUS_LIMITED, STATUS_UNKNOWN]
     )
-    tactile_paving = validators.String(enum=[STATUS_OK, STATUS_KO, STATUS_UNKNOWN])
     toilets_wheelchair = validators.String(
         enum=[STATUS_OK, STATUS_KO, STATUS_LIMITED, STATUS_UNKNOWN]
     )
@@ -23,8 +22,13 @@ class AccessibilityBlock(BaseBlock):
         properties = es_poi.get("properties", {})
 
         raw_wheelchair = properties.get("wheelchair")
-        raw_tactile_paving = properties.get("tactile_paving")
         raw_toilets_wheelchair = properties.get("toilets:wheelchair")
+
+        if all(
+            s is None
+            for s in (raw_wheelchair, raw_toilets_wheelchair)
+        ):
+            return None
 
         if raw_wheelchair in ("yes", "designated"):
             wheelchair = cls.STATUS_OK
@@ -34,13 +38,6 @@ class AccessibilityBlock(BaseBlock):
             wheelchair = cls.STATUS_KO
         else:
             wheelchair = cls.STATUS_UNKNOWN
-
-        if raw_tactile_paving == "yes":
-            tactile_paving = cls.STATUS_OK
-        elif raw_tactile_paving == "no":
-            tactile_paving = cls.STATUS_KO
-        else:
-            tactile_paving = cls.STATUS_UNKNOWN
 
         if raw_toilets_wheelchair == "yes":
             toilets_wheelchair = cls.STATUS_OK
@@ -53,13 +50,12 @@ class AccessibilityBlock(BaseBlock):
 
         if all(
             s == cls.STATUS_UNKNOWN
-            for s in (wheelchair, tactile_paving, toilets_wheelchair)
+            for s in (wheelchair, toilets_wheelchair)
         ):
             return None
 
         return cls(
             wheelchair=wheelchair,
-            tactile_paving=tactile_paving,
             toilets_wheelchair=toilets_wheelchair,
         )
 

--- a/tests/fixtures/cinema_multiplexe.json
+++ b/tests/fixtures/cinema_multiplexe.json
@@ -1,0 +1,143 @@
+{
+	"id": "osm:node:36153811",
+	"label": "Multiplexe Liberté (Brest)",
+	"name": "Multiplexe Liberté",
+	"coord": {
+		"lon": -4.487716849516516,
+		"lat": 48.39070125276485
+	},
+	"administrative_regions": [
+		{
+			"id": "admin:osm:relation:102430",
+			"insee": "29",
+			"level": 6,
+			"label": "Finistère, Bretagne, France",
+			"name": "Finistère",
+			"zip_codes": [
+
+			],
+			"weight": 0.000442342573601715,
+			"coord": {
+				"lon": -4.1024782,
+				"lat": 47.9960325
+			},
+			"admin_type": "Unknown",
+			"zone_type": "state_district"
+		},
+		{
+			"id": "admin:osm:relation:102740",
+			"insee": "53",
+			"level": 4,
+			"label": "Bretagne, France",
+			"name": "Bretagne",
+			"zip_codes": [
+
+			],
+			"weight": 0.02239740890685554,
+			"coord": {
+				"lon": -1.6800198,
+				"lat": 48.1113387
+			},
+			"admin_type": "Unknown",
+			"zone_type": "state"
+		},
+		{
+			"id": "admin:osm:relation:1076124",
+			"insee": "29019",
+			"level": 8,
+			"label": "Brest (29200), Finistère, Bretagne, France",
+			"name": "Brest",
+			"zip_codes": [
+				"29200"
+			],
+			"weight": 0.000983545754172197,
+			"coord": {
+				"lon": -4.4860088,
+				"lat": 48.3905283
+			},
+			"admin_type": "City",
+			"zone_type": "city"
+		},
+		{
+			"id": "admin:osm:relation:2202162",
+			"insee": "",
+			"level": 2,
+			"label": "France",
+			"name": "France",
+			"zip_codes": [
+
+			],
+			"weight": 0.015618298409952111,
+			"coord": {
+				"lon": 2.3514992,
+				"lat": 48.8566101
+			},
+			"admin_type": "Unknown",
+			"zone_type": "country"
+		}
+	],
+	"weight": 0,
+	"zip_codes": [
+		"29200"
+	],
+	"poi_type": {
+		"id": "cinema",
+		"name": "cinema"
+	},
+	"properties": [
+		{
+			"key": "toilets:wheelchair",
+			"value": "yes"
+		},
+		{
+			"key": "wheelchair",
+			"value": "yes"
+		},
+		{
+			"key": "amenity",
+			"value": "cinema"
+		},
+		{
+			"key": "cinema:3D",
+			"value": "yes"
+		},
+		{
+			"key": "name",
+			"value": "Multiplexe Liberté"
+		},
+		{
+			"key": "screen",
+			"value": "15"
+		},
+		{
+			"key": "name:latin",
+			"value": "Multiplexe Liberté"
+		},
+		{
+			"key": "name_int",
+			"value": "Multiplexe Liberté"
+		},
+		{
+			"key": "poi_subclass",
+			"value": "cinema"
+		},
+		{
+			"key": "poi_class",
+			"value": "cinema"
+		}
+	],
+	"address": {
+		"type": "addr",
+		"id": "addr:-4.487341;48.390743",
+		"house_number": "10",
+		"label": "10 Avenue Georges Clemenceau (Brest)",
+		"coord": {
+			"lon": -4.487341,
+			"lat": 48.390743
+		},
+		"weight": 0.000983545754172197,
+		"zip_codes": [
+			"29200"
+		]
+	}
+}

--- a/tests/fixtures/patisserie_peron.json
+++ b/tests/fixtures/patisserie_peron.json
@@ -1,0 +1,43 @@
+{
+	"id": "osm:node:738042332",
+	"label": "Boulangerie Patisserie Peron (Brest)",
+	"name": "Boulangerie Patisserie Peron",
+	"coord": {
+		"lon": -4.514629883321191,
+		"lat": 48.38264473507255
+	},
+	"weight": 0,
+	"zip_codes": [
+		"29200"
+	],
+	"poi_type": {
+		"id": "bakery",
+		"name": "bakery"
+	},
+	"properties": [
+		{
+			"key": "name_int",
+			"value": "Boulangerie Patisserie Peron"
+		},
+		{
+			"key": "shop",
+			"value": "bakery"
+		},
+		{
+			"key": "name",
+			"value": "Boulangerie Patisserie Peron"
+		},
+		{
+			"key": "name:latin",
+			"value": "Boulangerie Patisserie Peron"
+		},
+		{
+			"key": "poi_subclass",
+			"value": "bakery"
+		},
+		{
+			"key": "poi_class",
+			"value": "bakery"
+		}
+	]
+}

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,12 +1,13 @@
 from app import app
 from idunn.blocks.services_and_information import AccessibilityBlock
+from .test_api import patisserie_peron, cinema_multiplexe
+from apistar.test import TestClient
 
 def test_accessibility_block():
     web_block = AccessibilityBlock.from_es(
         {
             "properties": {
                 'wheelchair': 'limited',
-                'tactile_paving': 'yes',
                 'toilets:wheelchair': 'no'
             }
         },
@@ -14,9 +15,8 @@ def test_accessibility_block():
     )
 
     assert web_block == AccessibilityBlock(
-        wheelchair='limited',
-        tactile_paving='true',
-        toilets_wheelchair='false'
+        wheelchair='partial',
+        toilets_wheelchair='no'
     )
 
 
@@ -25,9 +25,68 @@ def test_accessibility_unknown():
         {
             "properties": {
                 'wheelchair': 'toto',
-                'tactile_paving': 'unknown',
             }
         },
         lang='en'
     )
     assert web_block is None
+
+def test_undefined_wheelchairs(patisserie_peron):
+    """
+    Test that when wheelchair and toilets_wheelchair are not
+    defined there is no block 'accessibility'
+    """
+    client = TestClient(app)
+    response = client.get(
+        url=f'http://localhost/v1/pois/{patisserie_peron}?lang=fr',
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get('Access-Control-Allow-Origin') == '*'
+
+    resp = response.json()
+
+    assert resp['id'] == 'osm:node:738042332'
+    assert resp['name'] == "Boulangerie Patisserie Peron"
+    assert resp['local_name'] == "Boulangerie Patisserie Peron"
+    assert resp['class_name'] == 'bakery'
+    assert resp['subclass_name'] == 'bakery'
+    assert resp['blocks'] == []
+
+def test_wheelchair(cinema_multiplexe):
+    """
+    Test that when wheelchair is defined but not toilets_wheelchair
+    we still have a correct block
+    """
+    client = TestClient(app)
+    response = client.get(
+        url=f'http://localhost/v1/pois/{cinema_multiplexe}?lang=fr',
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get('Access-Control-Allow-Origin') == '*'
+
+    resp = response.json()
+
+    assert resp['id'] == 'osm:node:36153811'
+    assert resp['name'] == "Multiplexe Liberté"
+    assert resp['local_name'] == "Multiplexe Liberté"
+    assert resp['class_name'] == 'cinema'
+    assert resp['subclass_name'] == 'cinema'
+    assert resp['blocks'] == [
+            {
+                "type": "information",
+                "blocks": [
+                    {
+                        "type": "services_and_information",
+                        "blocks": [
+                            {
+                                "type": "accessibility",
+                                "wheelchair": "yes",
+                                "toilets_wheelchair": "yes"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -55,8 +55,9 @@ def test_undefined_wheelchairs(patisserie_peron):
 
 def test_wheelchair(cinema_multiplexe):
     """
-    Test that when wheelchair is defined but not toilets_wheelchair
-    we still have a correct block
+    Test that Idunn returns the correct block when
+    both wheelchair and toilets_wheelchair tags
+    are defined
     """
     client = TestClient(app)
     response = client.get(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,21 @@ def load_poi(file_name, mimir_client):
         return poi_id
 
 @pytest.fixture(scope="session")
+def patisserie_peron(mimir_client, init_indices):
+    """
+    fill elasticsearch with a patisserie without the
+    tags 'wheelchair' and 'toilets:wheelchair' defined
+    """
+    return load_poi('patisserie_peron.json', mimir_client)
+
+@pytest.fixture(scope="session")
+def cinema_multiplexe(mimir_client, init_indices):
+    """
+    fill elasticsearch with a cinema_multiplexe 
+    """
+    return load_poi('cinema_multiplexe.json', mimir_client)
+
+@pytest.fixture(scope="session")
 def orsay_museum(mimir_client, init_indices):
     """
     fill elasticsearch with the orsay museum
@@ -163,8 +178,7 @@ def test_services_and_information(orsay_museum):
     assert resp.get('blocks')[2].get('blocks')[0].get('blocks') == [
 	{
 	    "type": "accessibility",
-	    "wheelchair": "true",
-	    "tactile_paving": "unknown",
+	    "wheelchair": "yes",
 	    "toilets_wheelchair": "unknown"
 	},
 	{

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -130,8 +130,7 @@ def test_full(fake_all_blocks):
                         "blocks": [
                             {
                                 "type": "accessibility",
-                                "wheelchair": "true",
-                                "tactile_paving": "unknown",
+                                "wheelchair": "yes",
                                 "toilets_wheelchair": "unknown"
                             },
                             {

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -102,8 +102,7 @@ def test_POI_not_in_WIKI_ES(orsay_museum, basket_ball_wiki_es):
         assert resp.get('blocks')[2].get('blocks')[0].get('blocks') == [
             {
                 "type": "accessibility",
-                "wheelchair": "true",
-                "tactile_paving": "unknown",
+                "wheelchair": "yes",
                 "toilets_wheelchair": "unknown"
             },
             {


### PR DESCRIPTION
This PR adapts the accessibility block to the following specifications:

* if wheelchair and toilets:wheelchair are both undefined : no accessibility block
* if wheelchair and toilets:wheelchair are both defined with unknown values: no accessibility block

Simple tests (from the specifications) come along the changes.