### PR TITLE
forceTZ for costal points

### DIFF
--- a/idunn/blocks/opening_hour.py
+++ b/idunn/blocks/opening_hour.py
@@ -34,7 +34,7 @@ def get_tz(es_poi):
         lon = coord.get('lon')
         lat = coord.get('lat')
         if lon is not None and lat is not None:
-            return timezone(tz.tzNameAt(lat, lon))
+            return timezone(tz.tzNameAt(lat, lon, forceTZ=True))
     return None
 
 


### PR DESCRIPTION
The library ([tzwhere](https://pypi.org/project/tzwhere/)) that Idunn uses to associate a timezone to a POI location fails when the POI is close to an ocean (c.f. https://github.com/mattbornski/tzwhere/issues/8).

A small trick to avoid this problem is to force the timezone `forceTZ=True` which will return then the closest timezone.