### PR TITLE
Add more logging facility for idunn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ADD idunn /app/idunn
 
 EXPOSE 5000
 
+ADD gunicorn_logging.conf .
 # You can set the number of workers by passing --workers=${NB_WORKER} to the docker run command.
 # For some reason, an array is required here to accept other params on run.
 ENTRYPOINT ["gunicorn", "app:app", "--bind=0.0.0.0:5000", "--pid=pid", \
-  "--worker-class=meinheld.gmeinheld.MeinheldWorker", "--preload"]
+  "--worker-class=meinheld.gmeinheld.MeinheldWorker", "--preload", "--log-config=/app/gunicorn_logging.conf"]

--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ python-redis-rate-limit = "*"
 lark-parser = "<0.6"
 prometheus-client = "*"
 apistar-prometheus = "*"
+python-json-logger = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d251523b0256566ba64657be94d26235e692abc1766a11388decbfdd03df8992"
+            "sha256": "7742d6af41c22ec8a27ca6aa0192456b2a4fa450768b47921af7bfe07d300217"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "4.8.0-53-generic",
+            "platform_release": "4.13.0-46-generic",
             "platform_system": "Linux",
-            "platform_version": "#56~16.04.1-Ubuntu SMP Tue May 16 01:18:56 UTC 2017",
+            "platform_version": "#51-Ubuntu SMP Tue Jun 12 12:36:29 UTC 2018",
             "python_full_version": "3.6.3",
             "python_version": "3.6",
             "sys_platform": "linux"
@@ -122,6 +122,13 @@
             ],
             "version": "==0.4.4"
         },
+        "python-json-logger": {
+            "hashes": [
+                "sha256:a292e22c5e03105a05a746ade6209d43db1c4c763b91c75c8486e81d10904d85",
+                "sha256:e3636824d35ba6a15fc39f573588cba63cf46322a5dc86fb2f280229077e9fbe"
+            ],
+            "version": "==0.1.9"
+        },
         "python-redis-rate-limit": {
             "hashes": [
                 "sha256:f3e9ef020e73793d9b5b109c57615effaf589106606fa2b008e2d6e6607dd4aa"
@@ -211,10 +218,10 @@
         },
         "whitenoise": {
             "hashes": [
-                "sha256:a6f86b011675b9730f69fd69d4f54c5697d6c7a90ab06f83f784d243d9fccc02",
-                "sha256:1e206c5adfb849942ddd057e599ac472ec1a85d56ae78a5ba24f243ea46a89c5"
+                "sha256:133a92ff0ab8fb9509f77d4f7d0de493eca19c6fea973f4195d4184f888f2e02",
+                "sha256:32b57d193478908a48acb66bf73e7a3c18679263e3e64bfebcfac1144a430039"
             ],
-            "version": "==4.0"
+            "version": "==4.1"
         }
     },
     "develop": {
@@ -267,12 +274,30 @@
             ],
             "version": "==4.3.0"
         },
+        "enum34": {
+            "hashes": [
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==1.1.6"
+        },
         "freezegun": {
             "hashes": [
                 "sha256:94c59d69bb99c9ec3ca5a3adb41930d3ea09d2a9756c23a02d89fa75646e78dd",
                 "sha256:703caac155dcaad61f78de4cb0666dca778d854dfb90b3699930adee0559a622"
             ],
             "version": "==0.3.10"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==1.0.2"
         },
         "idna": {
             "hashes": [
@@ -308,6 +333,14 @@
             ],
             "version": "==0.0.3"
         },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "markers": "python_version in '2.6, 2.7, 3.2'",
+            "version": "==2.0.0"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d",
@@ -323,12 +356,26 @@
             ],
             "version": "==0.3.1"
         },
+        "pathlib2": {
+            "hashes": [
+                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a",
+                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83"
+            ],
+            "markers": "python_version < '3.6'",
+            "version": "==2.3.2"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa",
+                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45"
+            ],
+            "version": "==4.2.0"
+        },
         "pexpect": {
             "hashes": [
                 "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b",
                 "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba"
             ],
-            "markers": "sys_platform != 'win32'",
             "version": "==4.6.0"
         },
         "pickleshare": {
@@ -402,6 +449,23 @@
             ],
             "version": "==0.9.0"
         },
+        "scandir": {
+            "hashes": [
+                "sha256:f5c71e29b4e2af7ccdc03a020c626ede51da471173b4a6ad1e904f2b2e04b4bd",
+                "sha256:1b5c314e39f596875e5a95dd81af03730b338c277c54a454226978d5ba95dbb6",
+                "sha256:346619f72eb0ddc4cf355ceffd225fa52506c92a2ff05318cfabd02a144e7c4e",
+                "sha256:1444134990356c81d12f30e4b311379acfbbcd03e0bab591de2696a3b126d58e",
+                "sha256:61859fd7e40b8c71e609c202db5b0c1dbec0d5c7f1449dec2245575bdc866792",
+                "sha256:c7708f29d843fc2764310732e41f0ce27feadde453261859ec0fca7865dfc41b",
+                "sha256:c9009c527929f6e25604aec39b0a43c3f831d2947d89d6caaab22f057b7055c8",
+                "sha256:c14701409f311e7a9b7ec8e337f0815baf7ac95776cc78b419a1e6d49889a383",
+                "sha256:04b8adb105f2ed313a7c2ef0f1cf7aff4871aa7a1883fa4d8c44b5551ab052d6",
+                "sha256:a5e232a0bf188362fa00123cc0bb842d363a292de7126126df5527b6a369586a",
+                "sha256:44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==1.9.0"
+        },
         "simplegeneric": {
             "hashes": [
                 "sha256:dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173"
@@ -421,6 +485,14 @@
                 "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835"
             ],
             "version": "==4.3.2"
+        },
+        "typing": {
+            "hashes": [
+                "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a",
+                "sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4",
+                "sha256:4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d"
+            ],
+            "version": "==3.6.6"
         },
         "urllib3": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -2,16 +2,20 @@ from apistar import App, Include
 
 from idunn.utils.settings import SettingsComponent
 from idunn.utils.es_wrapper import ElasticSearchComponent
+from idunn.utils.logging import init_logging
 from idunn.utils.cors import CORSHeaders
 from idunn.api.urls import api_urls
 
 from apistar_prometheus import PrometheusComponent, PrometheusHooks
 
+settings = SettingsComponent('IDUNN')
+
+init_logging(settings)
+
 routes = [
     Include('/v1', name='v1', routes=api_urls),
 ]
 
-settings = SettingsComponent('IDUNN')
 components = [
     settings,
     ElasticSearchComponent(),

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from apistar import App, Include
 
 from idunn.utils.settings import SettingsComponent
 from idunn.utils.es_wrapper import ElasticSearchComponent
-from idunn.utils.logging import init_logging
+from idunn.utils.logging import init_logging, LogErrorHook
 from idunn.utils.cors import CORSHeaders
 from idunn.api.urls import api_urls
 
@@ -22,7 +22,7 @@ components = [
     PrometheusComponent()
 ]
 
-event_hooks = [CORSHeaders, PrometheusHooks()]
+event_hooks = [LogErrorHook(), CORSHeaders, PrometheusHooks()]
 
 
 app = App(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
      - IDUNN_ES_URL=
      - IDUNN_WIKI_API_REDIS_URL=idunn-redis:6379
+     - IDUNN_LOG_JSON=1
 
   idunn-redis:
     image: redis:4

--- a/gunicorn_logging.conf
+++ b/gunicorn_logging.conf
@@ -1,0 +1,20 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=console
+
+[formatters]
+keys=json
+
+[logger_root]
+level=INFO
+handlers=console
+
+[handler_console]
+class=StreamHandler
+formatter=json
+args=(sys.stdout, )
+
+[formatter_json]
+class=pythonjsonlogger.jsonlogger.JsonFormatter

--- a/gunicorn_logging.conf
+++ b/gunicorn_logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root
+keys=root, gunicorn.error, gunicorn.access
 
 [handlers]
 keys=console
@@ -18,3 +18,16 @@ args=(sys.stdout, )
 
 [formatter_json]
 class=pythonjsonlogger.jsonlogger.JsonFormatter
+format=[%(asctime)s] [%(levelname)5s] [%(process)5s] [%(name)10s] %(message)s
+
+[logger_gunicorn.error]
+level=ERROR
+handlers=console
+propagate=0
+qualname=gunicorn.error
+
+[logger_gunicorn.access]
+level=INFO
+handlers=console
+propagate=0
+qualname=gunicorn.access

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -2,31 +2,25 @@
 MIMIR_ES: http://localhost:9200/
 
 WIKI_ES:
-
 WIKI_ES_TIMEOUT: 0.5 # seconds
-
 WIKI_ES_MAX_RETRIES: 0
-
 WIKI_USER_AGENT: 'Idunn' # Used in requests to external wiki* APIs
 
 DEFAULT_LANGUAGE: 'en' # Fallback when no 'lang' in request
 
 WIKI_API_CIRCUIT_TIMEOUT: 120 # seconds
-
 WIKI_API_CIRCUIT_MAXFAIL: 50
 
 ES_WIKI_LANG: "de,en,es,fr,it" # the (comma separated) list of languages existing in the WIKI_ES
 
 WIKI_API_RL_MAX_CALLS: 100 # Max number of external calls allowed by the rate limiter
-
 WIKI_API_RL_PERIOD: 1 # Duration (in seconds) of the period where no more than the max number of external calls are expected
-
 WIKI_API_REDIS_URL: # URL of the Redis service used by the rate limiter of the Wikipedia API calls
-
 WIKI_API_REDIS_DB: 0
-
 WIKI_CACHE_REDIS_DB: 1
-
 WIKI_REDIS_TIMEOUT: 1 # seconds
-
 WIKI_CACHE_TIMEOUT: 86400 # seconds
+
+LOG_LEVEL_BY_MODULE: '{"": "info", "elasticsearch": "warning"}' # json config to set, for each module a log level
+LOG_FORMAT: '[%(asctime)s] [%(levelname)5s] [%(process)5s] [%(name)10s] %(message)s' # logging format. if the log are json, it list the default fields
+LOG_JSON: False  # To get flat logs or json logs

--- a/idunn/utils/logging.py
+++ b/idunn/utils/logging.py
@@ -1,0 +1,42 @@
+from .settings import Settings
+from pythonjsonlogger import jsonlogger
+import logging
+import json
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    """We define our own sets of key to be more consistent with the other json logs"""
+
+    def _override_field(self, log_record, previous, new):
+        if previous in log_record:
+            log_record[new] = log_record.pop(previous)
+
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        self._override_field(log_record, 'message', 'msg')
+        self._override_field(log_record, 'levelname', 'level')
+        self._override_field(log_record, 'asctime', 'ts')
+
+def init_logging(settings: Settings):
+    """
+    init the logging for the server
+    """
+    log_format = settings['LOG_FORMAT']
+    as_json = settings['LOG_JSON']
+
+    levels = settings['LOG_LEVEL_BY_MODULE']
+    for module, lvl in json.loads(levels).items():
+        log_level = lvl.upper()
+        log_level = logging.getLevelName(log_level)
+        
+        logger = logging.getLogger(module)
+        logger.setLevel(log_level)
+
+    logHandler = logging.StreamHandler()
+    if as_json:
+        formatter = CustomJsonFormatter(log_format)
+        logHandler.setFormatter(formatter)
+    else:
+        logHandler.setFormatter(logging.Formatter(log_format))
+    
+    # we set this handler to the main logger
+    logging.getLogger().handlers = [logHandler]

--- a/idunn/utils/logging.py
+++ b/idunn/utils/logging.py
@@ -2,19 +2,7 @@ from .settings import Settings
 from pythonjsonlogger import jsonlogger
 import logging
 import json
-
-class CustomJsonFormatter(jsonlogger.JsonFormatter):
-    """We define our own sets of key to be more consistent with the other json logs"""
-
-    def _override_field(self, log_record, previous, new):
-        if previous in log_record:
-            log_record[new] = log_record.pop(previous)
-
-    def add_fields(self, log_record, record, message_dict):
-        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
-        self._override_field(log_record, 'message', 'msg')
-        self._override_field(log_record, 'levelname', 'level')
-        self._override_field(log_record, 'asctime', 'ts')
+from apistar import http
 
 def init_logging(settings: Settings):
     """
@@ -33,10 +21,18 @@ def init_logging(settings: Settings):
 
     logHandler = logging.StreamHandler()
     if as_json:
-        formatter = CustomJsonFormatter(log_format)
+        formatter = jsonlogger.JsonFormatter(log_format)
         logHandler.setFormatter(formatter)
     else:
         logHandler.setFormatter(logging.Formatter(log_format))
     
     # we set this handler to the main logger
     logging.getLogger().handlers = [logHandler]
+
+class LogErrorHook:
+    def on_response(self, response: http.Response, exc: Exception):
+        if exc is not None:
+            logging.getLogger('idunn.error').exception("handler returned an error")
+
+    def on_error(self, response: http.Response):
+        logging.getLogger('idunn.error').exception("An unhandled error was raised")

--- a/idunn/utils/logging.py
+++ b/idunn/utils/logging.py
@@ -30,9 +30,5 @@ def init_logging(settings: Settings):
     logging.getLogger().handlers = [logHandler]
 
 class LogErrorHook:
-    def on_response(self, response: http.Response, exc: Exception):
-        if exc is not None:
-            logging.getLogger('idunn.error').exception("handler returned an error")
-
     def on_error(self, response: http.Response):
         logging.getLogger('idunn.error').exception("An unhandled error was raised")

--- a/idunn/utils/settings.py
+++ b/idunn/utils/settings.py
@@ -2,7 +2,7 @@ import os
 import yaml
 from typing import Any
 from inspect import Parameter
-
+import logging
 from apistar import Component
 
 
@@ -39,7 +39,7 @@ class SettingsComponent(Component):
 
         self._load_from_env_var(project_name)
 
-        print(f"config: {self._settings}")
+        logging.debug(f"config: {self._settings}")
 
     def _load_default_config(self):
         """


### PR DESCRIPTION
The main thing is that we are now able to output json logs (for easier
ELK integration).

To enable it, the `IDUNN_LOG_JSON` must be set to 1.

`LOG_FORMAT` can be used to defined the logged fields / format
`LOG_LEVEL_BY_MODULE` can be set to define the log level for each module

Gunicorn now also output its log as json (and this is not configurable,
it's set in the Dockerfile)

should close #21