### PR TITLE
Grafana dashboard for prometheus metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     command: "--workers=4"
     environment:
-     - IDUNN_ES_URL=
+     - IDUNN_MIMIR_ES=
      - IDUNN_WIKI_API_REDIS_URL=idunn-redis:6379
 
   idunn-redis:

--- a/prometheus/graphana_dashboards.json
+++ b/prometheus/graphana_dashboards.json
@@ -1,0 +1,707 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "panels": [],
+      "title": "main metrics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "total queries done in idunn",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "http_requests_total{handler=\"idunn.api.pois.get_poi\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{handler}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "total queries",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "http_requests_inprogress{handler=\"idunn.api.pois.get_poi\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{dhanlder}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "request in progress",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 14,
+      "panels": [],
+      "title": "duration",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(http_request_duration_seconds_sum[1m])/rate(http_request_duration_seconds_count[1m])) by (handler)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{handler}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mean duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "median",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "90",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "99",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Percentile duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Rate limiter",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "limiter_too_many_requests_count",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "ratelimiter",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 22,
+      "panels": [],
+      "title": "wiki calls",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {}
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Panel Title",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(wiki_request_duration_seconds_sum[1m])/rate(wiki_request_duration_seconds_count[1m])) by (handler)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Panel Title",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2018-09-20T19:52:38.927Z",
+    "to": "2018-09-20T22:42:49.031Z"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Idunn dashboard",
+  "uid": "idunn_1",
+  "version": 3
+}

--- a/prometheus/graphana_dashboards.json
+++ b/prometheus/graphana_dashboards.json
@@ -1,707 +1,629 @@
 {
   "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": "-- Grafana --",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
+  "list": [
+  {
+  "builtIn": 1,
+  "datasource": "-- Grafana --",
+  "enable": true,
+  "hide": true,
+  "iconColor": "rgba(0, 211, 255, 1)",
+  "name": "Annotations & Alerts",
+  "type": "dashboard"
+  }
+  ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
   "links": [],
   "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 18,
-      "panels": [],
-      "title": "main metrics",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "description": "total queries done in idunn",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 1
-      },
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "http_requests_total{handler=\"idunn.api.pois.get_poi\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{handler}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "total queries",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 1
-      },
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "http_requests_inprogress{handler=\"idunn.api.pois.get_poi\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{dhanlder}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "request in progress",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 14,
-      "panels": [],
-      "title": "duration",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 11
-      },
-      "id": 4,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "avg(rate(http_request_duration_seconds_sum[1m])/rate(http_request_duration_seconds_count[1m])) by (handler)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{handler}}",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "mean duration",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 11
-      },
-      "id": 16,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "median",
-          "refId": "C"
-        },
-        {
-          "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "90",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "99",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Percentile duration",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 10,
-      "panels": [],
-      "title": "Rate limiter",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 21
-      },
-      "id": 8,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "limiter_too_many_requests_count",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "ratelimiter",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 30
-      },
-      "id": 22,
-      "panels": [],
-      "title": "wiki calls",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 31
-      },
-      "id": 24,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {}
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Panel Title",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 31
-      },
-      "id": 20,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "avg(rate(wiki_request_duration_seconds_sum[1m])/rate(wiki_request_duration_seconds_count[1m])) by (handler)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Panel Title",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    }
+  {
+  "collapsed": false,
+  "gridPos": {
+  "h": 1,
+  "w": 24,
+  "x": 0,
+  "y": 0
+  },
+  "id": 18,
+  "panels": [],
+  "title": "main metrics",
+  "type": "row"
+  },
+  {
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Prometheus",
+  "description": "total queries done in idunn",
+  "fill": 1,
+  "gridPos": {
+  "h": 9,
+  "w": 12,
+  "x": 0,
+  "y": 1
+  },
+  "id": 2,
+  "legend": {
+  "avg": false,
+  "current": false,
+  "max": false,
+  "min": false,
+  "show": true,
+  "total": false,
+  "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "spaceLength": 10,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+  {
+  "expr": "sum(rate(http_requests_total{handler=\"idunn.api.pois.get_poi\"}[1m])) by (code)",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "legendFormat": "{{handler}}-{{code}}",
+  "refId": "A"
+  }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "total queries",
+  "tooltip": {
+  "shared": true,
+  "sort": 0,
+  "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+  "buckets": null,
+  "mode": "time",
+  "name": null,
+  "show": true,
+  "values": []
+  },
+  "yaxes": [
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  },
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  }
+  ],
+  "yaxis": {
+  "align": false,
+  "alignLevel": null
+  }
+  },
+  {
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Prometheus",
+  "fill": 1,
+  "gridPos": {
+  "h": 9,
+  "w": 12,
+  "x": 12,
+  "y": 1
+  },
+  "id": 6,
+  "legend": {
+  "avg": false,
+  "current": false,
+  "max": false,
+  "min": false,
+  "show": true,
+  "total": false,
+  "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "spaceLength": 10,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+  {
+  "expr": "http_requests_inprogress{handler=\"idunn.api.pois.get_poi\"}",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "legendFormat": "{{dhanlder}}",
+  "refId": "A"
+  }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "request in progress",
+  "tooltip": {
+  "shared": true,
+  "sort": 0,
+  "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+  "buckets": null,
+  "mode": "time",
+  "name": null,
+  "show": true,
+  "values": []
+  },
+  "yaxes": [
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  },
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  }
+  ],
+  "yaxis": {
+  "align": false,
+  "alignLevel": null
+  }
+  },
+  {
+  "collapsed": false,
+  "gridPos": {
+  "h": 1,
+  "w": 24,
+  "x": 0,
+  "y": 10
+  },
+  "id": 14,
+  "panels": [],
+  "title": "duration",
+  "type": "row"
+  },
+  {
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Prometheus",
+  "fill": 1,
+  "gridPos": {
+  "h": 9,
+  "w": 12,
+  "x": 0,
+  "y": 11
+  },
+  "id": 4,
+  "legend": {
+  "avg": false,
+  "current": false,
+  "max": false,
+  "min": false,
+  "show": true,
+  "total": false,
+  "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "spaceLength": 10,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+  {
+  "expr": "avg(rate(http_request_duration_seconds_sum[1m])/rate(http_request_duration_seconds_count[1m])) by (handler)",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "legendFormat": "{{handler}}",
+  "refId": "B"
+  }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "mean duration",
+  "tooltip": {
+  "shared": true,
+  "sort": 0,
+  "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+  "buckets": null,
+  "mode": "time",
+  "name": null,
+  "show": true,
+  "values": []
+  },
+  "yaxes": [
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  },
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  }
+  ],
+  "yaxis": {
+  "align": false,
+  "alignLevel": null
+  }
+  },
+  {
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Prometheus",
+  "fill": 1,
+  "gridPos": {
+  "h": 9,
+  "w": 12,
+  "x": 12,
+  "y": 11
+  },
+  "id": 16,
+  "legend": {
+  "avg": false,
+  "current": false,
+  "max": false,
+  "min": false,
+  "show": true,
+  "total": false,
+  "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "spaceLength": 10,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+  {
+  "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "legendFormat": "median",
+  "refId": "C"
+  },
+  {
+  "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "legendFormat": "90",
+  "refId": "A"
+  },
+  {
+  "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "legendFormat": "99",
+  "refId": "B"
+  }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "Percentile duration",
+  "tooltip": {
+  "shared": true,
+  "sort": 0,
+  "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+  "buckets": null,
+  "mode": "time",
+  "name": null,
+  "show": true,
+  "values": []
+  },
+  "yaxes": [
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  },
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  }
+  ],
+  "yaxis": {
+  "align": false,
+  "alignLevel": null
+  }
+  },
+  {
+  "collapsed": false,
+  "gridPos": {
+  "h": 1,
+  "w": 24,
+  "x": 0,
+  "y": 20
+  },
+  "id": 10,
+  "panels": [],
+  "title": "Rate limiter",
+  "type": "row"
+  },
+  {
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Prometheus",
+  "fill": 1,
+  "gridPos": {
+  "h": 9,
+  "w": 12,
+  "x": 0,
+  "y": 21
+  },
+  "id": 8,
+  "legend": {
+  "avg": false,
+  "current": false,
+  "max": false,
+  "min": false,
+  "show": true,
+  "total": false,
+  "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "spaceLength": 10,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+  {
+  "expr": "limiter_too_many_requests_count",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "refId": "A"
+  }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "ratelimiter",
+  "tooltip": {
+  "shared": true,
+  "sort": 0,
+  "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+  "buckets": null,
+  "mode": "time",
+  "name": null,
+  "show": true,
+  "values": []
+  },
+  "yaxes": [
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  },
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  }
+  ],
+  "yaxis": {
+  "align": false,
+  "alignLevel": null
+  }
+  },
+  {
+  "collapsed": false,
+  "gridPos": {
+  "h": 1,
+  "w": 24,
+  "x": 0,
+  "y": 30
+  },
+  "id": 22,
+  "panels": [],
+  "title": "wiki calls",
+  "type": "row"
+  },
+  {
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Prometheus",
+  "fill": 1,
+  "gridPos": {
+  "h": 9,
+  "w": 12,
+  "x": 0,
+  "y": 31
+  },
+  "id": 20,
+  "legend": {
+  "avg": false,
+  "current": false,
+  "max": false,
+  "min": false,
+  "show": true,
+  "total": false,
+  "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "spaceLength": 10,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+  {
+  "expr": "avg(rate(wiki_request_duration_seconds_sum[1m])/rate(wiki_request_duration_seconds_count[1m])) by (handler)",
+  "format": "time_series",
+  "intervalFactor": 1,
+  "refId": "A"
+  }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "Panel Title",
+  "tooltip": {
+  "shared": true,
+  "sort": 0,
+  "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+  "buckets": null,
+  "mode": "time",
+  "name": null,
+  "show": true,
+  "values": []
+  },
+  "yaxes": [
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  },
+  {
+  "format": "short",
+  "label": null,
+  "logBase": 1,
+  "max": null,
+  "min": null,
+  "show": true
+  }
+  ],
+  "yaxis": {
+  "align": false,
+  "alignLevel": null
+  }
+  }
   ],
   "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+  "list": []
   },
   "time": {
-    "from": "2018-09-20T19:52:38.927Z",
-    "to": "2018-09-20T22:42:49.031Z"
+  "from": "now-15m",
+  "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
+  "refresh_intervals": [
+  "5s",
+  "10s",
+  "30s",
+  "1m",
+  "5m",
+  "15m",
+  "30m",
+  "1h",
+  "2h",
+  "1d"
+  ],
+  "time_options": [
+  "5m",
+  "15m",
+  "1h",
+  "6h",
+  "12h",
+  "24h",
+  "2d",
+  "7d",
+  "30d"
+  ]
   },
   "timezone": "",
   "title": "Idunn dashboard",
   "uid": "idunn_1",
-  "version": 3
-}
+  "version": 1
+  }

--- a/prometheus/graphana_dashboards.json
+++ b/prometheus/graphana_dashboards.json
@@ -1,629 +1,811 @@
 {
   "annotations": {
-  "list": [
-  {
-  "builtIn": 1,
-  "datasource": "-- Grafana --",
-  "enable": true,
-  "hide": true,
-  "iconColor": "rgba(0, 211, 255, 1)",
-  "name": "Annotations & Alerts",
-  "type": "dashboard"
-  }
-  ]
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "id": 1,
   "links": [],
   "panels": [
-  {
-  "collapsed": false,
-  "gridPos": {
-  "h": 1,
-  "w": 24,
-  "x": 0,
-  "y": 0
-  },
-  "id": 18,
-  "panels": [],
-  "title": "main metrics",
-  "type": "row"
-  },
-  {
-  "aliasColors": {},
-  "bars": false,
-  "dashLength": 10,
-  "dashes": false,
-  "datasource": "Prometheus",
-  "description": "total queries done in idunn",
-  "fill": 1,
-  "gridPos": {
-  "h": 9,
-  "w": 12,
-  "x": 0,
-  "y": 1
-  },
-  "id": 2,
-  "legend": {
-  "avg": false,
-  "current": false,
-  "max": false,
-  "min": false,
-  "show": true,
-  "total": false,
-  "values": false
-  },
-  "lines": true,
-  "linewidth": 1,
-  "links": [],
-  "nullPointMode": "null",
-  "percentage": false,
-  "pointradius": 5,
-  "points": false,
-  "renderer": "flot",
-  "seriesOverrides": [],
-  "spaceLength": 10,
-  "stack": false,
-  "steppedLine": false,
-  "targets": [
-  {
-  "expr": "sum(rate(http_requests_total{handler=\"idunn.api.pois.get_poi\"}[1m])) by (code)",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "legendFormat": "{{handler}}-{{code}}",
-  "refId": "A"
-  }
-  ],
-  "thresholds": [],
-  "timeFrom": null,
-  "timeShift": null,
-  "title": "total queries",
-  "tooltip": {
-  "shared": true,
-  "sort": 0,
-  "value_type": "individual"
-  },
-  "type": "graph",
-  "xaxis": {
-  "buckets": null,
-  "mode": "time",
-  "name": null,
-  "show": true,
-  "values": []
-  },
-  "yaxes": [
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  },
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  }
-  ],
-  "yaxis": {
-  "align": false,
-  "alignLevel": null
-  }
-  },
-  {
-  "aliasColors": {},
-  "bars": false,
-  "dashLength": 10,
-  "dashes": false,
-  "datasource": "Prometheus",
-  "fill": 1,
-  "gridPos": {
-  "h": 9,
-  "w": 12,
-  "x": 12,
-  "y": 1
-  },
-  "id": 6,
-  "legend": {
-  "avg": false,
-  "current": false,
-  "max": false,
-  "min": false,
-  "show": true,
-  "total": false,
-  "values": false
-  },
-  "lines": true,
-  "linewidth": 1,
-  "links": [],
-  "nullPointMode": "null",
-  "percentage": false,
-  "pointradius": 5,
-  "points": false,
-  "renderer": "flot",
-  "seriesOverrides": [],
-  "spaceLength": 10,
-  "stack": false,
-  "steppedLine": false,
-  "targets": [
-  {
-  "expr": "http_requests_inprogress{handler=\"idunn.api.pois.get_poi\"}",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "legendFormat": "{{dhanlder}}",
-  "refId": "A"
-  }
-  ],
-  "thresholds": [],
-  "timeFrom": null,
-  "timeShift": null,
-  "title": "request in progress",
-  "tooltip": {
-  "shared": true,
-  "sort": 0,
-  "value_type": "individual"
-  },
-  "type": "graph",
-  "xaxis": {
-  "buckets": null,
-  "mode": "time",
-  "name": null,
-  "show": true,
-  "values": []
-  },
-  "yaxes": [
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  },
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  }
-  ],
-  "yaxis": {
-  "align": false,
-  "alignLevel": null
-  }
-  },
-  {
-  "collapsed": false,
-  "gridPos": {
-  "h": 1,
-  "w": 24,
-  "x": 0,
-  "y": 10
-  },
-  "id": 14,
-  "panels": [],
-  "title": "duration",
-  "type": "row"
-  },
-  {
-  "aliasColors": {},
-  "bars": false,
-  "dashLength": 10,
-  "dashes": false,
-  "datasource": "Prometheus",
-  "fill": 1,
-  "gridPos": {
-  "h": 9,
-  "w": 12,
-  "x": 0,
-  "y": 11
-  },
-  "id": 4,
-  "legend": {
-  "avg": false,
-  "current": false,
-  "max": false,
-  "min": false,
-  "show": true,
-  "total": false,
-  "values": false
-  },
-  "lines": true,
-  "linewidth": 1,
-  "links": [],
-  "nullPointMode": "null",
-  "percentage": false,
-  "pointradius": 5,
-  "points": false,
-  "renderer": "flot",
-  "seriesOverrides": [],
-  "spaceLength": 10,
-  "stack": false,
-  "steppedLine": false,
-  "targets": [
-  {
-  "expr": "avg(rate(http_request_duration_seconds_sum[1m])/rate(http_request_duration_seconds_count[1m])) by (handler)",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "legendFormat": "{{handler}}",
-  "refId": "B"
-  }
-  ],
-  "thresholds": [],
-  "timeFrom": null,
-  "timeShift": null,
-  "title": "mean duration",
-  "tooltip": {
-  "shared": true,
-  "sort": 0,
-  "value_type": "individual"
-  },
-  "type": "graph",
-  "xaxis": {
-  "buckets": null,
-  "mode": "time",
-  "name": null,
-  "show": true,
-  "values": []
-  },
-  "yaxes": [
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  },
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  }
-  ],
-  "yaxis": {
-  "align": false,
-  "alignLevel": null
-  }
-  },
-  {
-  "aliasColors": {},
-  "bars": false,
-  "dashLength": 10,
-  "dashes": false,
-  "datasource": "Prometheus",
-  "fill": 1,
-  "gridPos": {
-  "h": 9,
-  "w": 12,
-  "x": 12,
-  "y": 11
-  },
-  "id": 16,
-  "legend": {
-  "avg": false,
-  "current": false,
-  "max": false,
-  "min": false,
-  "show": true,
-  "total": false,
-  "values": false
-  },
-  "lines": true,
-  "linewidth": 1,
-  "links": [],
-  "nullPointMode": "null",
-  "percentage": false,
-  "pointradius": 5,
-  "points": false,
-  "renderer": "flot",
-  "seriesOverrides": [],
-  "spaceLength": 10,
-  "stack": false,
-  "steppedLine": false,
-  "targets": [
-  {
-  "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "legendFormat": "median",
-  "refId": "C"
-  },
-  {
-  "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "legendFormat": "90",
-  "refId": "A"
-  },
-  {
-  "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "legendFormat": "99",
-  "refId": "B"
-  }
-  ],
-  "thresholds": [],
-  "timeFrom": null,
-  "timeShift": null,
-  "title": "Percentile duration",
-  "tooltip": {
-  "shared": true,
-  "sort": 0,
-  "value_type": "individual"
-  },
-  "type": "graph",
-  "xaxis": {
-  "buckets": null,
-  "mode": "time",
-  "name": null,
-  "show": true,
-  "values": []
-  },
-  "yaxes": [
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  },
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  }
-  ],
-  "yaxis": {
-  "align": false,
-  "alignLevel": null
-  }
-  },
-  {
-  "collapsed": false,
-  "gridPos": {
-  "h": 1,
-  "w": 24,
-  "x": 0,
-  "y": 20
-  },
-  "id": 10,
-  "panels": [],
-  "title": "Rate limiter",
-  "type": "row"
-  },
-  {
-  "aliasColors": {},
-  "bars": false,
-  "dashLength": 10,
-  "dashes": false,
-  "datasource": "Prometheus",
-  "fill": 1,
-  "gridPos": {
-  "h": 9,
-  "w": 12,
-  "x": 0,
-  "y": 21
-  },
-  "id": 8,
-  "legend": {
-  "avg": false,
-  "current": false,
-  "max": false,
-  "min": false,
-  "show": true,
-  "total": false,
-  "values": false
-  },
-  "lines": true,
-  "linewidth": 1,
-  "links": [],
-  "nullPointMode": "null",
-  "percentage": false,
-  "pointradius": 5,
-  "points": false,
-  "renderer": "flot",
-  "seriesOverrides": [],
-  "spaceLength": 10,
-  "stack": false,
-  "steppedLine": false,
-  "targets": [
-  {
-  "expr": "limiter_too_many_requests_count",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "refId": "A"
-  }
-  ],
-  "thresholds": [],
-  "timeFrom": null,
-  "timeShift": null,
-  "title": "ratelimiter",
-  "tooltip": {
-  "shared": true,
-  "sort": 0,
-  "value_type": "individual"
-  },
-  "type": "graph",
-  "xaxis": {
-  "buckets": null,
-  "mode": "time",
-  "name": null,
-  "show": true,
-  "values": []
-  },
-  "yaxes": [
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  },
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  }
-  ],
-  "yaxis": {
-  "align": false,
-  "alignLevel": null
-  }
-  },
-  {
-  "collapsed": false,
-  "gridPos": {
-  "h": 1,
-  "w": 24,
-  "x": 0,
-  "y": 30
-  },
-  "id": 22,
-  "panels": [],
-  "title": "wiki calls",
-  "type": "row"
-  },
-  {
-  "aliasColors": {},
-  "bars": false,
-  "dashLength": 10,
-  "dashes": false,
-  "datasource": "Prometheus",
-  "fill": 1,
-  "gridPos": {
-  "h": 9,
-  "w": 12,
-  "x": 0,
-  "y": 31
-  },
-  "id": 20,
-  "legend": {
-  "avg": false,
-  "current": false,
-  "max": false,
-  "min": false,
-  "show": true,
-  "total": false,
-  "values": false
-  },
-  "lines": true,
-  "linewidth": 1,
-  "nullPointMode": "null",
-  "percentage": false,
-  "pointradius": 5,
-  "points": false,
-  "renderer": "flot",
-  "seriesOverrides": [],
-  "spaceLength": 10,
-  "stack": false,
-  "steppedLine": false,
-  "targets": [
-  {
-  "expr": "avg(rate(wiki_request_duration_seconds_sum[1m])/rate(wiki_request_duration_seconds_count[1m])) by (handler)",
-  "format": "time_series",
-  "intervalFactor": 1,
-  "refId": "A"
-  }
-  ],
-  "thresholds": [],
-  "timeFrom": null,
-  "timeShift": null,
-  "title": "Panel Title",
-  "tooltip": {
-  "shared": true,
-  "sort": 0,
-  "value_type": "individual"
-  },
-  "type": "graph",
-  "xaxis": {
-  "buckets": null,
-  "mode": "time",
-  "name": null,
-  "show": true,
-  "values": []
-  },
-  "yaxes": [
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  },
-  {
-  "format": "short",
-  "label": null,
-  "logBase": 1,
-  "max": null,
-  "min": null,
-  "show": true
-  }
-  ],
-  "yaxis": {
-  "align": false,
-  "alignLevel": null
-  }
-  }
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "panels": [],
+      "title": "main metrics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "total queries done in idunn",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{handler=\"idunn.api.pois.get_poi\"}[1m])) by (code)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{handler}}-{{code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "total queries",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 12,
+        "y": 1
+      },
+      "id": 26,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(http_requests_total)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Nb queries all time",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 14,
+        "y": 1
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(http_requests_inprogress{handler=\"idunn.api.pois.get_poi\"}) by (handler)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{handler}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "request in progress",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 14,
+      "panels": [],
+      "title": "duration",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(http_request_duration_seconds_sum[1m])/rate(http_request_duration_seconds_count[1m])) by (handler)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{handler}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mean duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "median",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "90",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "99",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Percentile duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Errors",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(idunn_exceptions_count[1m])) by (exception_type)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{exception_type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 22,
+      "panels": [],
+      "title": "wiki calls",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(http_request_duration_seconds_sum[1m])/rate(http_request_duration_seconds_count[1m])) by (handler, target)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{target}} - {{handler}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "wikipedia mean duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(idunn_wiki_request_duration_seconds_bucket[1m])) by (le, target, handler))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "50 - {{target}} - {{handler}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(idunn_wiki_request_duration_seconds_bucket[1m])) by (le, target, handler))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "90 - {{target}} - {{handler}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(idunn_wiki_request_duration_seconds_bucket[1m])) by (le, target, handler))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "99 - {{target}} - {{handler}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "wikipedia percentile duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
   ],
   "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
   "templating": {
-  "list": []
+    "list": []
   },
   "time": {
-  "from": "now-15m",
-  "to": "now"
+    "from": "now-1h",
+    "to": "now"
   },
   "timepicker": {
-  "refresh_intervals": [
-  "5s",
-  "10s",
-  "30s",
-  "1m",
-  "5m",
-  "15m",
-  "30m",
-  "1h",
-  "2h",
-  "1d"
-  ],
-  "time_options": [
-  "5m",
-  "15m",
-  "1h",
-  "6h",
-  "12h",
-  "24h",
-  "2d",
-  "7d",
-  "30d"
-  ]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "",
   "title": "Idunn dashboard",
   "uid": "idunn_1",
-  "version": 1
-  }
+  "version": 6
+}

--- a/prometheus/graphana_dashboards_provisioner.yaml
+++ b/prometheus/graphana_dashboards_provisioner.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'default'
+  orgId: 1
+  folder: ''
+  type: file
+  disableDeletion: false
+  updateIntervalSeconds: 3 #how often Grafana will scan for changed dashboards
+  options:
+    path: /etc/grafana/provisioning/dashboards

--- a/prometheus/graphana_datasource.yaml
+++ b/prometheus/graphana_datasource.yaml
@@ -1,0 +1,9 @@
+# config file version
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  access: browser
+  url: http://localhost:9090
+ 

--- a/prometheus/prometheus-compose.yml
+++ b/prometheus/prometheus-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+services:
+  grafana:
+    image: grafana/grafana
+    ports:
+    - 3000:3000
+    volumes:
+    - grafana_data:/var/lib/grafana
+    - ./prometheus/graphana_dashboards_provisioner.yaml:/etc/grafana/provisioning/dashboards/graphana_dashboards_provisioner.yaml
+    - ./prometheus/graphana_dashboards.json:/etc/grafana/provisioning/dashboards/graphana_dashboards.json
+    - ./prometheus/graphana_datasource.yaml:/etc/grafana/provisioning/datasources/graphana_datasource.yaml
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+    depends_on:
+      - prometheus
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+    - 9090:9090
+    volumes:
+    - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    - prometheus_data:/prometheus
+    command:
+    - --config.file=/etc/prometheus/prometheus.yml
+
+  idunn:
+    ports:
+    - 5000:5000
+    environment:
+     - IDUNN_MIMIR_ES=
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'idunn'
+    scrape_interval: 1s
+    metrics_path: '/v1/metrics'
+    static_configs:
+      - targets: ['idunn:5000']

--- a/prometheus/readme.md
+++ b/prometheus/readme.md
@@ -1,0 +1,15 @@
+# Prometheus
+
+These are dev prometheus setup to see Idunn's metric.
+This is absolutly not to be used in production!
+
+To test it, you need to run the idunn's docker-compose with the additional prometheus compose.
+In the main idunn's directory:
+
+`docker-compose -f docker-compose.yml -f prometheus/prometheus-compose.yml up --build`
+
+Then you can query idunn on `localhost:5000` and access graphana on `http://localhost:3000/d/idunn_1/idunn-dashboard`.
+
+(graphana's accesses are user: `admin`, password: `admin`).
+
+If you change the dashboard, don't forget to export to json  and change the file `graphana_dashboards.json`.


### PR DESCRIPTION
Add a dev prometheus/grafana setup to see the metrics

These are dev prometheus setup to see Idunn's metric.
This is absolutely not to be used in production!

To test it, you need to run the idunn's docker-compose with the additional prometheus compose. 
In the main idunn's directory:

`docker-compose -f docker-compose.yml -f prometheus/prometheus-compose.yml up --build`

Then you can query idunn on `localhost:5000` and access graphana on `http://localhost:3000/d/idunn_1/idunn-dashboard`.

(graphana's accesses are user: `admin`, password: `admin`).

If you change the dashboard, don't forget to export to json  and change the file `graphana_dashboards.json`.

NOTE: the dashboard is not complete, lots of metrics will need to be added after #30 

the dashboard look like this:
![image](https://user-images.githubusercontent.com/3987698/45868205-6c4bb100-bd85-11e8-8846-b1f2fc7b07c2.png)
