### PR TITLE
add a ready status

### DIFF
--- a/idunn/api/status.py
+++ b/idunn/api/status.py
@@ -14,9 +14,15 @@ def get_status(es: Elasticsearch):
     else:
         es_reachable = True
 
+    es_cluster_health = cluster_health.get('status') in ES_RUNNING_STATUS
+
+    # the 'ready' is used as the readyness probe.
+    # for the moment idunn is ready if ES is reachable
+    ready = es_cluster_health
     return {
         'es': {
             'reachable': es_reachable,
-            'running': cluster_health.get('status') in ES_RUNNING_STATUS
-        }
+            'running': es_cluster_health
+        },
+        'ready': ready
     }

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -11,7 +11,7 @@ def test_v1_status_ok(mimir_es):
     response = client.get("http://localhost/v1/status")
 
     assert response.status_code == 200
-    assert response.json() == {"es": {"reachable": True, "running": True}}
+    assert response.json() == {"es": {"reachable": True, "running": True}, "ready": True}
 
 
 @patch.object(ClusterClient, "health", new=lambda *args: {"status": "red"})
@@ -20,7 +20,7 @@ def test_v1_status_es_red(mimir_es):
     response = client.get("http://localhost/v1/status")
 
     assert response.status_code == 200
-    assert response.json() == {"es": {"reachable":True, "running": False}}
+    assert response.json() == {"es": {"reachable":True, "running": False}, "ready": False}
 
 
 @patch.object(ClusterClient, "health")
@@ -31,4 +31,4 @@ def test_v1_status_es_unreachable(mock_es_health, mimir_es):
     response = client.get("http://localhost/v1/status")
 
     assert response.status_code == 200
-    assert response.json() == {"es": {"reachable":False, "running": False}}
+    assert response.json() == {"es": {"reachable":False, "running": False}, "ready": False}


### PR DESCRIPTION
add a `ready` field  in `/status` to have an easy readyness probe