### PR TITLE
Catch Redis interruption

### DIFF
--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -143,10 +143,8 @@ class WikipediaCache:
     def set_value(cls, key, json_result):
         try:
             cls._connection.set(key, json_result, ex=cls._expire)
-            return True
         except RedisError:
             logging.exception("Got a RedisError")
-            return False
 
     @classmethod
     def get_value(cls, key):
@@ -203,8 +201,7 @@ class WikipediaCache:
                     return json.loads(value_stored.decode('utf-8'))
                 result = f(*args, **kwargs)
                 json_result = json.dumps(result)
-                if not cls.set_value(key, json_result):
-                    return None
+                cls.set_value(key, json_result)
                 return result
             return f(*args, **kwargs)
         return with_cache

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -144,6 +144,7 @@ class WikipediaCache:
         try:
             cls._connection.set(key, json_result, ex=cls._expire)
         except RedisError:
+            prometheus.exception("RedisError")
             logging.exception("Got a RedisError")
 
     @classmethod
@@ -152,6 +153,7 @@ class WikipediaCache:
             value_stored = cls._connection.get(key)
             return value_stored
         except RedisError:
+            prometheus.exception("RedisError")
             logging.exception("Got a RedisError")
             return None
 


### PR DESCRIPTION
RedisError was catch in the rate limiter and in the init_cache() but not in the cache.
This PR just proposes to catch it also in the cache in order to prevent any Redis interruption.