### PR TITLE
Do not fetch wiki content if cache is not reachable

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "7742d6af41c22ec8a27ca6aa0192456b2a4fa450768b47921af7bfe07d300217"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "4.8.0-53-generic",
-            "platform_system": "Linux",
-            "platform_version": "#56~16.04.1-Ubuntu SMP Tue May 16 01:18:56 UTC 2017",
-            "python_full_version": "3.6.3",
-            "python_version": "3.6",
-            "sys_platform": "linux"
-        },
         "pipfile-spec": 6,
         "requires": {
             "python_version": "3.6"
@@ -33,13 +20,15 @@
             "hashes": [
                 "sha256:fe489b053aa2c4e92c329494ed39300b53f81f0be6e22bec9d9e2cf8d71ae28e"
             ],
+            "index": "pypi",
             "version": "==0.5.42"
         },
         "apistar-prometheus": {
             "hashes": [
-                "sha256:8cde790821451e7b8b1bf23ad20ab33c6d654941e52cd574d94966c8530982fd",
-                "sha256:65a4e20b09ed6053822a13025c3399127b3fce750241bba807fd99fa71bab9a3"
+                "sha256:65a4e20b09ed6053822a13025c3399127b3fce750241bba807fd99fa71bab9a3",
+                "sha256:8cde790821451e7b8b1bf23ad20ab33c6d654941e52cd574d94966c8530982fd"
             ],
+            "index": "pypi",
             "version": "==0.6.0"
         },
         "babel": {
@@ -47,6 +36,7 @@
                 "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
                 "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
             ],
+            "index": "pypi",
             "version": "==2.6.0"
         },
         "certifi": {
@@ -58,8 +48,8 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
         },
@@ -75,6 +65,7 @@
                 "sha256:bb8f9a365ba6650d599428538c8aed42033264661d8f7d353da59d5892305f72",
                 "sha256:fead47ebfcaabd1c53dbfc21403eb99ac207eef76de8002fe11a1c8ec9589ce2"
             ],
+            "index": "pypi",
             "version": "==2.4.1"
         },
         "idna": {
@@ -95,6 +86,7 @@
             "hashes": [
                 "sha256:2074f2cda9303167f97da0157eefa6fdf9c0b8c7786d4a24e86c65319b34c0df"
             ],
+            "index": "pypi",
             "version": "==0.5.6"
         },
         "markupsafe": {
@@ -105,21 +97,24 @@
         },
         "osm-humanized-opening-hours": {
             "hashes": [
-                "sha256:327e1db0f87bb8242901b977236e6572dc75746547f6196f1bf4d442796dbe72",
-                "sha256:0bf6eac962fda54e73260d400ece72d84b857150f6bf6b839b514075b3641120"
+                "sha256:0bf6eac962fda54e73260d400ece72d84b857150f6bf6b839b514075b3641120",
+                "sha256:327e1db0f87bb8242901b977236e6572dc75746547f6196f1bf4d442796dbe72"
             ],
+            "index": "pypi",
             "version": "==0.6.2"
         },
         "prometheus-client": {
             "hashes": [
                 "sha256:046cb4fffe75e55ff0e6dfd18e2ea16e54d86cc330f369bebcc683475c8b68a9"
             ],
+            "index": "pypi",
             "version": "==0.4.2"
         },
         "pybreaker": {
             "hashes": [
                 "sha256:c034de4e8d0501bda05dcab21e08f43a4956cf59c1605c8b8d1504ad790d5aa9"
             ],
+            "index": "pypi",
             "version": "==0.4.4"
         },
         "python-json-logger": {
@@ -127,34 +122,36 @@
                 "sha256:a292e22c5e03105a05a746ade6209d43db1c4c763b91c75c8486e81d10904d85",
                 "sha256:e3636824d35ba6a15fc39f573588cba63cf46322a5dc86fb2f280229077e9fbe"
             ],
+            "index": "pypi",
             "version": "==0.1.9"
         },
         "python-redis-rate-limit": {
             "hashes": [
                 "sha256:f3e9ef020e73793d9b5b109c57615effaf589106606fa2b008e2d6e6607dd4aa"
             ],
+            "index": "pypi",
             "version": "==0.0.6"
         },
         "pytz": {
             "hashes": [
-                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece",
-                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b"
+                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b",
+                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece"
             ],
             "version": "==2018.6"
         },
         "pyyaml": {
             "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
                 "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
                 "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
             "version": "==3.13"
         },
@@ -163,36 +160,38 @@
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
                 "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
             ],
+            "index": "pypi",
             "version": "==2.10.6"
         },
         "requests": {
             "hashes": [
-                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279",
-                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c"
+                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
+                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
             ],
+            "index": "pypi",
             "version": "==2.20.0"
         },
         "shapely": {
             "hashes": [
-                "sha256:3ca69d4b12e2b05b549465822744b6a3a1095d8488cc27b2728a06d3c07d0eee",
-                "sha256:714b6680215554731389a1bbdae4cec61741aa4726921fa2b2b96a6f578a2534",
-                "sha256:5d22a1a705c2f70f61ccadc696e33d922c1a92e00df8e1d58a6ade14dd7e3b4f",
-                "sha256:34e7c6f41fb27906ccdf2514ee44a5774b90b39a256b6511a6a57d11ffe64999",
-                "sha256:3e9388f29bd81fcd4fa5c35125e1fbd4975ee36971a87a90c093f032d0e9de24",
                 "sha256:0378964902f89b8dbc332e5bdfa08e0bc2f7ab39fecaeb17fbb2a7699a44fe71",
-                "sha256:523c94403047eb6cacd7fc1863ebef06e26c04d8a4e7f8f182d49cd206fe787e",
-                "sha256:ba58b21b9cf3c33725f7f530febff9ed6a6846f9d0bf8a120fc74683ff919f89",
-                "sha256:ebb4d2bee7fac3f6c891fcdafaa17f72ab9c6480f6d00de0b2dc9a5137dfe342",
-                "sha256:7dfe1528650c3f0dc82f41a74cf4f72018288db9bfb75dcd08f6f04233ec7e78",
+                "sha256:34e7c6f41fb27906ccdf2514ee44a5774b90b39a256b6511a6a57d11ffe64999",
+                "sha256:3ca69d4b12e2b05b549465822744b6a3a1095d8488cc27b2728a06d3c07d0eee",
+                "sha256:3e9388f29bd81fcd4fa5c35125e1fbd4975ee36971a87a90c093f032d0e9de24",
                 "sha256:3ef28e3f20a1c37f5b99ea8cf8dcb58e2f1a8762d65ed2d21fd92bf1d4811182",
-                "sha256:c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f"
+                "sha256:523c94403047eb6cacd7fc1863ebef06e26c04d8a4e7f8f182d49cd206fe787e",
+                "sha256:5d22a1a705c2f70f61ccadc696e33d922c1a92e00df8e1d58a6ade14dd7e3b4f",
+                "sha256:714b6680215554731389a1bbdae4cec61741aa4726921fa2b2b96a6f578a2534",
+                "sha256:7dfe1528650c3f0dc82f41a74cf4f72018288db9bfb75dcd08f6f04233ec7e78",
+                "sha256:ba58b21b9cf3c33725f7f530febff9ed6a6846f9d0bf8a120fc74683ff919f89",
+                "sha256:c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f",
+                "sha256:ebb4d2bee7fac3f6c891fcdafaa17f72ab9c6480f6d00de0b2dc9a5137dfe342"
             ],
             "version": "==1.6.4.post2"
         },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         },
@@ -200,19 +199,20 @@
             "hashes": [
                 "sha256:b9a056e60f6ad5d44e7bc9d397ae683ea4bcd81f812ab6bbdfaad3d9984fcf19"
             ],
+            "index": "pypi",
             "version": "==3.0.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59",
-                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae"
+                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
+                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
             "version": "==1.24"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b",
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c"
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
             ],
             "version": "==0.14.1"
         },
@@ -234,8 +234,8 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb",
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "version": "==18.2.0"
         },
@@ -262,8 +262,8 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
         },
@@ -279,6 +279,7 @@
                 "sha256:6cb82b276f83f2acce67f121dc2656f4df26c71e32238334eb071170b892a278",
                 "sha256:e839b43bfbe8158b4d62bb97e6313d39f3586daf48e1314fb1083d2ef17700da"
             ],
+            "index": "pypi",
             "version": "==0.3.11"
         },
         "idna": {
@@ -293,6 +294,7 @@
                 "sha256:47b17ea874454a5c2eacc2732b04a750d260b01ba479323155ac8a39031f5535",
                 "sha256:9fed506c3772c875a3048bc134a25e6f5e997b1569b2636f6a5d891f34cbfd46"
             ],
+            "index": "pypi",
             "version": "==7.0.1"
         },
         "ipython-genutils": {
@@ -313,64 +315,65 @@
             "hashes": [
                 "sha256:238ed21dd56d070dfd23e78663ecdb8ff49a7c24f5fa1c370e4fb95476f5b1ae"
             ],
+            "index": "pypi",
             "version": "==0.0.3"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d",
                 "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e"
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
             ],
             "version": "==4.3.0"
         },
         "parso": {
             "hashes": [
-                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24",
-                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2"
+                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
+                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
             ],
             "version": "==0.3.1"
         },
         "pexpect": {
             "hashes": [
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b",
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba"
+                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
+                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
             ],
             "markers": "sys_platform != 'win32'",
             "version": "==4.6.0"
         },
         "pickleshare": {
             "hashes": [
-                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56",
-                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
             ],
             "version": "==0.7.5"
         },
         "pluggy": {
             "hashes": [
-                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f",
-                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095"
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
             "version": "==0.8.0"
         },
         "prompt-toolkit": {
             "hashes": [
                 "sha256:646b3401b3b0bb7752100bc9b7aeecb36cb09cdfc63652b5856708b5ba8db7da",
-                "sha256:ccad8461b5d912782726af17122113e196085e7e11d57cf0c9b982bf1ab2c7be",
-                "sha256:82766ffd7397e6661465e20bd1390db0781ca4fbbab4cf6c2578cacdd8b09754"
+                "sha256:82766ffd7397e6661465e20bd1390db0781ca4fbbab4cf6c2578cacdd8b09754",
+                "sha256:ccad8461b5d912782726af17122113e196085e7e11d57cf0c9b982bf1ab2c7be"
             ],
             "version": "==2.0.6"
         },
         "ptyprocess": {
             "hashes": [
-                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f",
-                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
             ],
             "version": "==0.6.0"
         },
         "py": {
             "hashes": [
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6",
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694"
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
             "version": "==1.7.0"
         },
@@ -383,9 +386,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6f6c1efc8d0ccc21f8f6c34d8330baca883cf109b66b3df954b0a117e5528fb4",
-                "sha256:212be78a6fa5352c392738a49b18f74ae9aeec1040f47c81cadbfd8d1233c310"
+                "sha256:212be78a6fa5352c392738a49b18f74ae9aeec1040f47c81cadbfd8d1233c310",
+                "sha256:6f6c1efc8d0ccc21f8f6c34d8330baca883cf109b66b3df954b0a117e5528fb4"
             ],
+            "index": "pypi",
             "version": "==3.9.2"
         },
         "python-dateutil": {
@@ -397,16 +401,18 @@
         },
         "requests": {
             "hashes": [
-                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279",
-                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c"
+                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
+                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
             ],
+            "index": "pypi",
             "version": "==2.20.0"
         },
         "responses": {
             "hashes": [
-                "sha256:f171f3cc74a6550b68c600c89f913e59337360ac7c1e563cee44a980833a0354",
-                "sha256:9a165718944c0ac3215e2507f4d63b5a6a44da883df8949a7ae659516f4ef883"
+                "sha256:9a165718944c0ac3215e2507f4d63b5a6a44da883df8949a7ae659516f4ef883",
+                "sha256:f171f3cc74a6550b68c600c89f913e59337360ac7c1e563cee44a980833a0354"
             ],
+            "index": "pypi",
             "version": "==0.10.1"
         },
         "simplegeneric": {
@@ -417,29 +423,29 @@
         },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         },
         "traitlets": {
             "hashes": [
-                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9",
-                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835"
+                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
+                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
             ],
             "version": "==4.3.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59",
-                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae"
+                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
+                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
             "version": "==1.24"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c",
-                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
         }

--- a/idunn/utils/redis.py
+++ b/idunn/utils/redis.py
@@ -1,0 +1,23 @@
+from redis import ConnectionPool, RedisError
+
+REDIS_URL_SETTING = 'WIKI_API_REDIS_URL'
+REDIS_TIMEOUT_SETTING = 'WIKI_REDIS_TIMEOUT'
+
+class RedisNotConfigured(RedisError):
+    pass
+
+def get_redis_pool(settings, db):
+    redis_url = settings[REDIS_URL_SETTING]
+    redis_timeout = int(settings[REDIS_TIMEOUT_SETTING])
+
+    if not redis_url:
+        raise RedisNotConfigured('Missing redis url: %s not set' % REDIS_URL_SETTING)
+
+    if not redis_url.startswith('redis://'):
+        redis_url = 'redis://' + redis_url
+
+    return ConnectionPool.from_url(
+        url=redis_url,
+        socket_timeout=redis_timeout,
+        db=db
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def init_indices(mimir_client, wiki_client):
 def mock_external_requests():
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add('GET',
-                 re.compile('^https://.*\.wikipedia.org/'),
+                 re.compile(r'^https://.*\.wikipedia.org/'),
                  status=404)
         yield
 

--- a/tests/test_api_circuit_breaker.py
+++ b/tests/test_api_circuit_breaker.py
@@ -41,7 +41,7 @@ def test_circuit_breaker_500(breaker_test):
     client = TestClient(app)
     with responses.RequestsMock() as rsps:
         rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
+             re.compile(r'^https://.*\.wikipedia.org/'),
              status=500)
         """
         We mock 10 calls to wikipedia while the max number
@@ -86,7 +86,7 @@ def test_circuit_breaker_404(breaker_test):
     client = TestClient(app)
     with responses.RequestsMock() as rsps:
         rsps.add('GET',
-                re.compile('^https://.*\.wikipedia.org/'),
+                re.compile(r'^https://.*\.wikipedia.org/'),
                 status=404)
         """
         Even after more requests than the max number of

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -46,7 +46,7 @@ def limiter_test_interruption(redis):
         yield
     WikipediaLimiter._limiter = None
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function')
 def mock_wikipedia(redis):
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add(
@@ -136,7 +136,7 @@ def test_rate_limiter_without_redis():
 
     with responses.RequestsMock() as rsps:
         rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
+             re.compile(r'^https://.*\.wikipedia.org/'),
              status=200,
              json={"test": "test"}
         )
@@ -236,7 +236,7 @@ def test_rate_limiter_with_redisError(limiter_test_interruption, mock_wikipedia,
     assert any(b['type'] == "wikipedia" for b in resp['blocks'][2].get('blocks'))
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=2)
-def test_rate_limiter_with_redis_interruption(docker_services, redis, limiter_test_interruption):
+def test_rate_limiter_with_redis_interruption(docker_services, mock_wikipedia, limiter_test_interruption):
     """
     Test that Idunn isn't impacted by any Redis interruption:
     If Redis service stops then the wikipedia block should not be returned.

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -43,7 +43,7 @@ def test_basket_ball():
     client = TestClient(app)
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
+             re.compile(r'^https://.*\.wikipedia.org/'),
              status=200)
 
         response = client.get(
@@ -84,7 +84,7 @@ def test_WIKI_ES_KO(wiki_client_ko):
     client = TestClient(app)
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
+             re.compile(r'^https://.*\.wikipedia.org/'),
              status=200,
              json={"test": "test"})
 
@@ -156,7 +156,7 @@ def test_undefined_WIKI_ES(undefine_wiki_es):
     client = TestClient(app)
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
+             re.compile(r'^https://.*\.wikipedia.org/'),
              status=200,
              json={"test": "test"})
 
@@ -176,7 +176,7 @@ def test_POI_not_in_WIKI_ES():
     client = TestClient(app)
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
+             re.compile(r'^https://.*\.wikipedia.org/'),
              status=200)
 
         response = client.get(
@@ -240,7 +240,7 @@ def test_no_lang_WIKI_ES():
     client = TestClient(app)
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add('GET',
-             re.compile('^https://.*\.wikipedia.org/'),
+             re.compile(r'^https://.*\.wikipedia.org/'),
              status=200,
              json={"test": "test"})
 


### PR DESCRIPTION
* Cache will not try to resolve wikipedia content if redis is not reachable
* Define `get_redis_pool` function in utils, to refactor Redis initialization
* Rate-limiter and cache connections are set to `DISABLED_STATE` (more explicit and less confusing than `False`) when these features are not enabled in settings 