### PR TITLE
Implement source param and a new verbosity when fetching multiple places

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,8 +22,9 @@ python-redis-rate-limit = "*"
 prometheus-client = "*"
 apistar-prometheus = "*"
 python-json-logger = "*"
-osm-humanized-opening-hours = {editable = true, ref = "d249acd791467d073cc4ef35cf14ac5ab0c429ae", git = "https://github.com/rezemika/humanized_opening_hours.git"}
 pydantic = "*"
+lark-parser = "<0.7"
+osm_humanized_opening_hours = {git = "https://github.com/rezemika/humanized_opening_hours.git", ref = "d249acd791467d073cc4ef35cf14ac5ab0c429ae", editable = true}
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9a201c3f0b52d8213298f5876bcf3c92124042046a8e2f629c372893a7629e7b"
+            "sha256": "e62cbd4c875e3504c3956c000d0acde3f5a6ee82917f9ca882830b3b3a9c7b3f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,10 +48,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -92,16 +92,17 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "lark-parser": {
             "hashes": [
-                "sha256:43d623edae6f16db038d29f8586406002f2bea63c0363dc9acbedac27de7040e"
+                "sha256:062800f3823a6c733ec1d181a2089a22d1f62dbe65f90a3f6b1e6de1934b05ef"
             ],
-            "version": "==0.6.6"
+            "index": "pypi",
+            "version": "==0.6.7"
         },
         "markupsafe": {
             "hashes": [
@@ -150,26 +151,25 @@
         },
         "pybreaker": {
             "hashes": [
-                "sha256:71856aa75de7365088baa452a5bbac6845f19c93f28391a0799c17658a4b3089"
+                "sha256:53e1d532e6d8924646cafbdffabfc3d383ada7a6d7ef6d5a01aad7eb4ad1742f"
             ],
             "index": "pypi",
-            "version": "==0.4.5"
+            "version": "==0.5.0"
         },
         "pydantic": {
             "hashes": [
-                "sha256:72bad4962ee13fe153333378f0eddb69bdf7044c8d547db88518c6c9a6f5491b",
-                "sha256:7c796d79efe96a9f2835abd6c3e0ebadab69328f2637e9b0bb92a22425dc4273"
+                "sha256:4edf4c55a25ebc2d5041aa1bbe46fbf9b6b823bacfbc1e79c032e8e6d25dbae5",
+                "sha256:e384498a6a66cf3ff855b3141e53e245271a827c2ddffb401fefaa06c21d2e4b"
             ],
             "index": "pypi",
-            "version": "==0.20.1"
+            "version": "==0.24"
         },
         "python-json-logger": {
             "hashes": [
-                "sha256:3e000053837500f9eb28d6228d7cb99fabfc1874d34b40c08289207292abaf2e",
-                "sha256:cf2caaf34bd2eff394915b6242de4d0245de79971712439380ece6f149748cde"
+                "sha256:b7a31162f2a01965a5efb94453ce69230ed208468b0bbc7fdfc56e6d8df2e281"
             ],
             "index": "pypi",
-            "version": "==0.1.10"
+            "version": "==0.1.11"
         },
         "python-redis-rate-limit": {
             "hashes": [
@@ -180,34 +180,34 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
-            "version": "==2018.9"
+            "version": "==2019.1"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
             ],
-            "version": "==3.13"
+            "version": "==5.1"
         },
         "redis": {
             "hashes": [
-                "sha256:724932360d48e5407e8f82e405ab3650a36ed02c7e460d1e6fddf0f038422b54",
-                "sha256:9b19425a38fd074eb5795ff2b0d9a55b46a44f91f5347995f27e3ad257a7d775"
+                "sha256:6946b5dca72e86103edc8033019cc3814c031232d339d5f4533b02ea85685175",
+                "sha256:8ca418d2ddca1b1a850afa1680a7d2fd1f3322739271de4b704e0d4668449273"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==3.2.1"
         },
         "requests": {
             "hashes": [
@@ -250,17 +250,17 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a",
+                "sha256:7fad9770a8778f9576693f0cc29c7dcc36964df916b83734f4431c0e612a7fbc"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.2"
         },
         "whitenoise": {
             "hashes": [
@@ -280,10 +280,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "backcall": {
             "hashes": [
@@ -294,10 +294,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -308,10 +308,10 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e",
-                "sha256:cabb249f4710888a2fc0e13e9a16c343d932033718ff62e1e9bc93a9d3a9122b"
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
             ],
-            "version": "==4.3.2"
+            "version": "==4.4.0"
         },
         "freezegun": {
             "hashes": [
@@ -330,11 +330,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:06de667a9e406924f97781bda22d5d76bfb39762b678762d86a466e63f65dc39",
-                "sha256:5d3e020a6b5f29df037555e5c45ab1088d6a7cf3bd84f47e0ba501eeb0c3ec82"
+                "sha256:b038baa489c38f6d853a3cfc4c635b0cda66f2864d136fe8f40c1a6e334e2a6b",
+                "sha256:f5102c1cd67e399ec8ea66bcebe6e3968ea25a8977e53f012963e5affeb1fe38"
             ],
             "index": "pypi",
-            "version": "==7.3.0"
+            "version": "==7.4.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -359,26 +359,26 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "version": "==7.0.0"
         },
         "parso": {
             "hashes": [
-                "sha256:4580328ae3f548b358f4901e38c0578229186835f0fa0846e47369796dd5bcc9",
-                "sha256:68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db"
+                "sha256:17cc2d7a945eb42c3569d4564cdf49bde221bc2b552af3eca9c1aad517dcdd33",
+                "sha256:2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376"
             ],
-            "version": "==0.3.4"
+            "version": "==0.4.0"
         },
         "pexpect": {
             "hashes": [
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==4.6.0"
+            "version": "==4.7.0"
         },
         "pickleshare": {
             "hashes": [
@@ -425,11 +425,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
-                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
+                "sha256:3773f4c235918987d51daf1db66d51c99fac654c81d6f2f709a046ab446d5e5d",
+                "sha256:b7802283b70ca24d7119b32915efa7c409982f59913c1a6c0640aacf118b95f5"
             ],
             "index": "pypi",
-            "version": "==4.3.0"
+            "version": "==4.4.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -448,11 +448,11 @@
         },
         "responses": {
             "hashes": [
-                "sha256:c85882d2dc608ce6b5713a4e1534120f4a0dc6ec79d1366570d2b0c909a50c87",
-                "sha256:ea5a14f9aea173e3b786ff04cf03133c2dabd4103dbaef1028742fd71a6c2ad3"
+                "sha256:502d9c0c8008439cfcdef7e251f507fcfdd503b56e8c0c87c3c3e3393953f790",
+                "sha256:97193c0183d63fba8cd3a041c75464e4b09ea0aff6328800d1546598567dde0b"
             ],
             "index": "pypi",
-            "version": "==0.10.5"
+            "version": "==0.10.6"
         },
         "six": {
             "hashes": [
@@ -470,10 +470,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "wcwidth": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@
 `GET /schema`
 
 The main endpoints are:
-* `/v1/places/{place_id}?lang={lang}&type={type}&verbosity={verbosity}` to get the details of a place (admin, street, address or POI). The `type` parameter belongs to the set `{'admin', 'street', 'address', 'poi'}`. The `verbosity` parameter belongs to the set `{'long', 'short'}`. The default verbosity is `long`.
+* `/v1/places/{place_id}?lang={lang}&type={type}&verbosity={verbosity}` to get the details of a place
+(admin, street, address or POI).
+    * `type`: (optionnal) parameter belongs to the set `{'admin', 'street', 'address', 'poi'}`
+    * `verbosity` parameter belongs to the set `{'long', 'short'}`. The default verbosity is `long`.
+* `/v1/places?bbox={bbox}&category=<category-name>&size={size}` to get a list of all points of interest matching the given bbox and categories
+    * `bbox`: left,bot,right,top e.g. `bbox=2.0,48.0,3.0,49.0`
+    * `category`: multiple values are accepted (e.g. `category=leisure&category=museum`)
+    * `size`: maximum number of places in the response'
+    * `verbosity`: default verbosity is `list` (equivalent to `long`, except "information" and "wiki" blocks are not returned)
 * `/v1/places?bbox={bbox}&raw_filter=class,subclass&size={size}` to get a list of all points of interest matching the given bbox (=left,bot,right,top e.g. `bbox=2,48,3,49`) and the raw filters (e.g. `raw_filter=*,restaurant&raw_filter=shop,*&raw_filter=bakery,bakery`)
-* `/v1/places?bbox={bbox}&category=<category-name>&size={size}` to get a list of all points of interest matching the given bbox (=left,bot,right,top e.g. `bbox=2,48,3,49`) and the categories (e.g. `category=leisure&category=museum`)
-* `/v1/categories` to get the list of all the categories you can filter.
-* `/v1/pois/{poi_id}?lang={lang}` is the deprecated route to get the details of a POI.
+* `/v1/categories` to get the list of all the categories you can filter on.
+* `/v1/pois/{poi_id}?lang={lang}` is the **deprecated** route to get the details of a POI.
 * `/v1/status` to get the status of the API and associated ES cluster.
 * `/v1/metrics` to get some metrics on the API that give statistics on the number of requests received, the duration of requests... This endpoint can be scraped by Prometheus.
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@
 The main endpoints are:
 * `/v1/places/{place_id}?lang={lang}&type={type}&verbosity={verbosity}` to get the details of a place
 (admin, street, address or POI).
-    * `type`: (optionnal) parameter belongs to the set `{'admin', 'street', 'address', 'poi'}`
+    * `type`: (optional) parameter belongs to the set `{'admin', 'street', 'address', 'poi'}`
     * `verbosity` parameter belongs to the set `{'long', 'short'}`. The default verbosity is `long`.
 * `/v1/places?bbox={bbox}&category=<category-name>&size={size}` to get a list of all points of interest matching the given bbox and categories
     * `bbox`: left,bot,right,top e.g. `bbox=2.0,48.0,3.0,49.0`
     * `category`: multiple values are accepted (e.g. `category=leisure&category=museum`)
-    * `size`: maximum number of places in the response'
+    * `size`: maximum number of places in the response
     * `verbosity`: default verbosity is `list` (equivalent to `long`, except "information" and "wiki" blocks are not returned)
+    * `source`: (optional) to force a data source (instead of automated selection based on coverage). Accepted values: `osm`, `pagesjaunes`
 * `/v1/places?bbox={bbox}&raw_filter=class,subclass&size={size}` to get a list of all points of interest matching the given bbox (=left,bot,right,top e.g. `bbox=2,48,3,49`) and the raw filters (e.g. `raw_filter=*,restaurant&raw_filter=shop,*&raw_filter=bakery,bakery`)
 * `/v1/categories` to get the list of all the categories you can filter on.
 * `/v1/pois/{poi_id}?lang={lang}` is the **deprecated** route to get the details of a POI.

--- a/idunn/api/places.py
+++ b/idunn/api/places.py
@@ -6,20 +6,18 @@ from idunn.utils import prometheus
 from idunn.utils.settings import Settings
 from idunn.utils.index_names import IndexNames
 from idunn.places import Place, Admin, Street, Address, POI
-from idunn.api.utils import fetch_es_place, LONG, SHORT, DEFAULT_VERBOSITY
+from idunn.api.utils import fetch_es_place, DEFAULT_VERBOSITY, ALL_VERBOSITY_LEVELS
 from idunn.api.pages_jaunes import pj_source
 
 logger = logging.getLogger(__name__)
 
-VERBOSITY_LEVELS = [LONG, SHORT]
 
 def get_place(id, es: Elasticsearch, indices: IndexNames, settings: Settings, lang=None, type=None, verbosity=DEFAULT_VERBOSITY) -> Place:
     """Main handler that returns the requested place"""
-    if verbosity not in VERBOSITY_LEVELS:
-        raise BadRequest(
-            status_code=400,
-            detail={"message": f"verbosity {verbosity} does not belong to the set of possible verbosity values={VERBOSITY_LEVELS}"}
-        )
+    if verbosity not in ALL_VERBOSITY_LEVELS:
+        raise BadRequest({
+            "message": f"Unknown verbosity '{verbosity}'. Accepted values are {ALL_VERBOSITY_LEVELS}"
+        })
 
     if not lang:
         lang = settings['DEFAULT_LANGUAGE']
@@ -41,7 +39,6 @@ def get_place(id, es: Elasticsearch, indices: IndexNames, settings: Settings, la
 
     if loader is None:
         prometheus.exception("FoundPlaceWithWrongType")
-        logger.error("The place with the id {} has a wrong type: {}".format(id, es_place[0].get('_type')))
-        return None
+        raise Exception("Place with id '{}' has a wrong type: '{}'".format(id, es_place[0].get('_type')))
 
     return loader(es_place['_source']).load_place(lang, verbosity)

--- a/idunn/api/places_list.py
+++ b/idunn/api/places_list.py
@@ -21,6 +21,9 @@ logger = logging.getLogger(__name__)
 MAX_WIDTH = 1.0 # max bbox longitude in degrees
 MAX_HEIGHT = 1.0  # max bbox latitude in degrees
 
+SOURCE_OSM = 'osm'
+SOURCE_PAGESJAUNES = 'pagesjaunes'
+ALL_SOURCES = [SOURCE_OSM, SOURCE_PAGESJAUNES]
 
 def get_categories():
     categories_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../utils/categories.yml")
@@ -35,6 +38,7 @@ class PlacesQueryParam(BaseModel):
     size: Optional[int] = None
     lang: str = None
     verbosity: str = DEFAULT_VERBOSITY_LIST
+    source: Optional[str] = None
 
     def __init__(self, **data: Any):
         super().__init__(**data)
@@ -52,6 +56,12 @@ class PlacesQueryParam(BaseModel):
     def valid_verbosity(cls, v):
         if v not in ALL_VERBOSITY_LEVELS:
             raise ValueError(f"the verbosity: \'{v}\' does not belong to possible verbosity levels: {VERBOSITY_LEVELS}")
+        return v
+
+    @validator('source')
+    def valid_source(cls, v):
+        if v not in ALL_SOURCES:
+            raise ValueError(f"unknown source: '{v}'")
         return v
 
     @validator('bbox')
@@ -108,12 +118,20 @@ def get_places_bbox(bbox, es: Elasticsearch, indices: IndexNames, settings: Sett
             detail={"message": e.errors()}
         )
 
-    if params.category \
-        and all(c.get('pj_filters') for c in params.category) \
-        and pj_source.bbox_is_covered(params.bbox) :
+    source = params.source
+    if source is None:
+        if params.category \
+            and all(c.get('pj_filters') for c in params.category) \
+            and pj_source.bbox_is_covered(params.bbox):
+            source = SOURCE_PAGESJAUNES
+        else:
+            source = SOURCE_OSM
+
+    if source == SOURCE_PAGESJAUNES:
         all_categories = [pj_category for c in params.category for pj_category in c['pj_filters']]
         places_list = pj_source.get_places_bbox(all_categories, params.bbox, size=params.size)
     else:
+        # Default source (OSM)
         if params.raw_filter:
             raw_filters = params.raw_filter
         else:

--- a/idunn/api/places_list.py
+++ b/idunn/api/places_list.py
@@ -6,8 +6,8 @@ from apistar.exceptions import BadRequest
 from idunn import settings
 from idunn.utils.settings import Settings, _load_yaml_file
 from idunn.utils.index_names import IndexNames
-from idunn.places import POI, PjPOI
-from idunn.api.utils import fetch_bbox_places, LONG, SHORT, DEFAULT_VERBOSITY_LIST
+from idunn.places import POI
+from idunn.api.utils import fetch_bbox_places, DEFAULT_VERBOSITY_LIST, ALL_VERBOSITY_LEVELS
 from .pages_jaunes import pj_source
 
 from apistar import http
@@ -17,8 +17,6 @@ from pydantic.error_wrappers import ErrorWrapper
 from typing import List, Optional, Any
 
 logger = logging.getLogger(__name__)
-
-VERBOSITY_LEVELS = [LONG, SHORT]
 
 MAX_WIDTH = 1.0 # max bbox longitude in degrees
 MAX_HEIGHT = 1.0  # max bbox latitude in degrees
@@ -52,7 +50,7 @@ class PlacesQueryParam(BaseModel):
 
     @validator('verbosity', pre=True, always=True)
     def valid_verbosity(cls, v):
-        if v not in VERBOSITY_LEVELS:
+        if v not in ALL_VERBOSITY_LEVELS:
             raise ValueError(f"the verbosity: \'{v}\' does not belong to possible verbosity levels: {VERBOSITY_LEVELS}")
         return v
 

--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 LONG = "long"
 SHORT = "short"
+LIST = "list"
 DEFAULT_VERBOSITY = LONG
-DEFAULT_VERBOSITY_LIST = SHORT
+DEFAULT_VERBOSITY_LIST = LIST
 
 BLOCKS_BY_VERBOSITY = {
     LONG: [
@@ -25,10 +26,18 @@ BLOCKS_BY_VERBOSITY = {
         ImagesBlock,
         GradesBlock
     ],
+    LIST: [
+        OpeningHourBlock,
+        PhoneBlock,
+        WebSiteBlock,
+        ImagesBlock,
+        GradesBlock
+    ],
     SHORT: [
         OpeningHourBlock
     ]
 }
+ALL_VERBOSITY_LEVELS = list(BLOCKS_BY_VERBOSITY.keys())
 
 PLACE_DEFAULT_INDEX = settings['PLACE_DEFAULT_INDEX']
 PLACE_POI_INDEX = settings['PLACE_POI_INDEX']

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -37,6 +37,18 @@ class PjPOI(BasePlace):
             return 'cinema'
         if 'salles de concerts, de spectacles' in raw_categories:
             return 'theatre'
+        if 'Pharmacie' in raw_categories:
+            return 'pharmacy'
+        if 'supermarchés, hypermarchés' in raw_categories:
+            return 'grocery'
+        if 'banques' in raw_categories:
+            return 'bank'
+        if 'cafés, bars' in raw_categories:
+            return 'bar'
+        if any(k in c for c in raw_categories for k in ('écoles ','collèges ','lycées ')):
+            return 'school'
+        if any('enseignement supérieur' in c for c in raw_categories):
+            return 'college'
         return None
 
     def get_subclass_name(self):

--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -34,8 +34,20 @@ categories:
         raw_filters:
             - "bank,*"
     education:
+        pj_filters:
+            - "écoles maternelles publiques"
+            - "écoles primaires publiques"
+            - "collèges publics"
+            - "lycées d'enseignement général et technologique publics"
+            - "écoles maternelles privées"
+            - "écoles primaires privées"
+            - "collèges privés"
+            - "lycées d'enseignement général et technologique privés"
+            - "enseignement supérieur public"
+            - "enseignement supérieur privé"
         raw_filters:
             - "school,*"
+            - "college,*"
     bar:
         pj_filters:
             - "cafés, bars"

--- a/idunn/utils/geometry.py
+++ b/idunn/utils/geometry.py
@@ -55,6 +55,6 @@ def parse_poly(lines):
 with open(france_poly_filename) as france_file:
     france_polygon = parse_poly(france_file.readlines())
 
-def bbox_inside_polygon(minx, miny, maxx, maxy, poly, threshold=0.8):
+def bbox_inside_polygon(minx, miny, maxx, maxy, poly, threshold=0.75):
     rect = box(minx, miny, maxx, maxy)
     return poly.intersection(rect).area / rect.area > threshold

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -61,10 +61,14 @@ def test_bbox():
                     ]
                 },
                 'blocks': [
-                    {'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T21:45:00+02:00',
-                     'seconds_before_next_transition': 40500, 'is_24_7': False,
-                     'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
-                     'days': [{'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
+                    {
+                        'type': 'opening_hours',
+                        'status': 'open',
+                        'next_transition_datetime': '2018-06-14T21:45:00+02:00',
+                        'seconds_before_next_transition': 40500,
+                        'is_24_7': False,
+                        'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
+                        'days': [{'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
                               {'dayofweek': 2, 'local_date': '2018-06-12', 'status': 'open',
                                'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
                               {'dayofweek': 3, 'local_date': '2018-06-13', 'status': 'open',
@@ -76,7 +80,19 @@ def test_bbox():
                               {'dayofweek': 6, 'local_date': '2018-06-16', 'status': 'open',
                                'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
                               {'dayofweek': 7, 'local_date': '2018-06-17', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}]}],
+                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}]
+                    },
+                    {
+                        'type': 'phone',
+                        'international_format': '+33140494814',
+                        'local_format': '+33140494814',
+                        'url': 'tel:+33140494814'
+                    },
+                    {
+                        'type': 'website',
+                        'url': 'http://www.musee-orsay.fr'
+                    }
+                ],
                 'meta': {
                     'source': 'osm'
                 }
@@ -91,7 +107,18 @@ def test_bbox():
                 'geometry': {'type': 'Point', 'coordinates': [2.3577366716253647, 48.858955519212905],
                              'center': [2.3577366716253647, 48.858955519212905]},
                 'address': ANY,
-                'blocks': [],
+                'blocks': [
+                    {
+                        'international_format': '+33 1 42 72 09 37',
+                        'local_format': '+33 1 42 72 09 37',
+                        'type': 'phone',
+                        'url': 'tel:+33 1 42 72 09 37'
+                    },
+                    {
+                        'type': 'website',
+                        'url': 'http://www.paris.catholique.fr/-Notre-Dame-des-Blancs-Manteaux,1290-.html'
+                    }
+                ],
                 'meta': {
                     'source': 'osm'
                 }
@@ -107,22 +134,37 @@ def test_bbox():
                              'center': [2.338027583323689, 48.86114726113347]},
                 'address': ANY,
                 'blocks': [
-                    {'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T18:00:00+02:00',
-                     'seconds_before_next_transition': 27000, 'is_24_7': False,
-                     'raw': 'Mo,Th,Sa,Su 09:00-18:00; We,Fr 09:00-21:45; Tu off; Jan 1,May 1,Dec 25: off', 'days': [
-                        {'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'open',
-                         'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]},
-                        {'dayofweek': 2, 'local_date': '2018-06-12', 'status': 'closed', 'opening_hours': []},
-                        {'dayofweek': 3, 'local_date': '2018-06-13', 'status': 'open',
-                         'opening_hours': [{'beginning': '09:00', 'end': '21:45'}]},
-                        {'dayofweek': 4, 'local_date': '2018-06-14', 'status': 'open',
-                         'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]},
-                        {'dayofweek': 5, 'local_date': '2018-06-15', 'status': 'open',
-                         'opening_hours': [{'beginning': '09:00', 'end': '21:45'}]},
-                        {'dayofweek': 6, 'local_date': '2018-06-16', 'status': 'open',
-                         'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]},
-                        {'dayofweek': 7, 'local_date': '2018-06-17', 'status': 'open',
-                         'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]}]}],
+                    {
+                        'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T18:00:00+02:00',
+                        'seconds_before_next_transition': 27000, 'is_24_7': False,
+                        'raw': 'Mo,Th,Sa,Su 09:00-18:00; We,Fr 09:00-21:45; Tu off; Jan 1,May 1,Dec 25: off',
+                        'days': [
+                            {'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'open',
+                             'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]},
+                            {'dayofweek': 2, 'local_date': '2018-06-12', 'status': 'closed', 'opening_hours': []},
+                            {'dayofweek': 3, 'local_date': '2018-06-13', 'status': 'open',
+                             'opening_hours': [{'beginning': '09:00', 'end': '21:45'}]},
+                            {'dayofweek': 4, 'local_date': '2018-06-14', 'status': 'open',
+                             'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]},
+                            {'dayofweek': 5, 'local_date': '2018-06-15', 'status': 'open',
+                             'opening_hours': [{'beginning': '09:00', 'end': '21:45'}]},
+                            {'dayofweek': 6, 'local_date': '2018-06-16', 'status': 'open',
+                             'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]},
+                            {'dayofweek': 7, 'local_date': '2018-06-17', 'status': 'open',
+                             'opening_hours': [{'beginning': '09:00', 'end': '18:00'}]}
+                        ]
+                    },
+                    {
+                        'international_format': '+33 1 40 20 52 29',
+                        'local_format': '+33 1 40 20 52 29',
+                        'type': 'phone',
+                        'url': 'tel:+33 1 40 20 52 29'
+                    },
+                    {
+                        'type': 'website',
+                        'url': 'http://www.louvre.fr'
+                    }
+                ],
                 'meta': {
                     'source': 'osm'
                 }
@@ -138,10 +180,11 @@ def test_bbox():
                              'center': [2.3250037768187326, 48.86618482685007]},
                 'address': ANY,
                 'blocks': [
-                    {'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T21:45:00+02:00',
-                     'seconds_before_next_transition': 40500, 'is_24_7': False,
-                     'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
-                     'days': [{'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
+                    {
+                        'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T21:45:00+02:00',
+                        'seconds_before_next_transition': 40500, 'is_24_7': False,
+                        'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
+                        'days': [{'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
                               {'dayofweek': 2, 'local_date': '2018-06-12', 'status': 'open',
                                'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
                               {'dayofweek': 3, 'local_date': '2018-06-13', 'status': 'open',
@@ -153,7 +196,12 @@ def test_bbox():
                               {'dayofweek': 6, 'local_date': '2018-06-16', 'status': 'open',
                                'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
                               {'dayofweek': 7, 'local_date': '2018-06-17', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}]}],
+                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}
+                        ]
+                    },
+                    ANY,
+                    ANY
+                ],
                 'meta': {
                     'source': 'osm'
                 }
@@ -172,10 +220,11 @@ def test_bbox():
                             'street': {'id': 'street:553660044C', 'name': 'Rue de Lille',
                                        'label': 'Rue de Lille (Paris)', 'postcodes': ['75007', '75008']}, 'admins': []},
                 'blocks': [
-                    {'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T21:45:00+02:00',
-                     'seconds_before_next_transition': 40500, 'is_24_7': False,
-                     'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
-                     'days': [{'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
+                    {
+                        'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T21:45:00+02:00',
+                        'seconds_before_next_transition': 40500, 'is_24_7': False,
+                        'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
+                        'days': [{'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
                               {'dayofweek': 2, 'local_date': '2018-06-12', 'status': 'open',
                                'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
                               {'dayofweek': 3, 'local_date': '2018-06-13', 'status': 'open',
@@ -187,7 +236,12 @@ def test_bbox():
                               {'dayofweek': 6, 'local_date': '2018-06-16', 'status': 'open',
                                'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
                               {'dayofweek': 7, 'local_date': '2018-06-17', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}]}],
+                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}
+                        ]
+                    },
+                    ANY,
+                    ANY
+                ],
                 'meta': {
                     'source': 'osm'
                 }
@@ -224,22 +278,36 @@ def test_size_list():
                              'center': [2.3265827716099623, 48.859917803575875]},
                 'address': ANY,
                 'blocks': [
-                    {'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T21:45:00+02:00',
-                     'seconds_before_next_transition': 40500, 'is_24_7': False,
-                     'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
-                     'days': [{'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
-                              {'dayofweek': 2, 'local_date': '2018-06-12', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
-                              {'dayofweek': 3, 'local_date': '2018-06-13', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
-                              {'dayofweek': 4, 'local_date': '2018-06-14', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '21:45'}]},
-                              {'dayofweek': 5, 'local_date': '2018-06-15', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
-                              {'dayofweek': 6, 'local_date': '2018-06-16', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
-                              {'dayofweek': 7, 'local_date': '2018-06-17', 'status': 'open',
-                               'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}]}
+                    {
+                        'type': 'opening_hours', 'status': 'open', 'next_transition_datetime': '2018-06-14T21:45:00+02:00',
+                        'seconds_before_next_transition': 40500, 'is_24_7': False,
+                        'raw': 'Tu-Su 09:30-18:00; Th 09:30-21:45',
+                        'days': [
+                            {'dayofweek': 1, 'local_date': '2018-06-11', 'status': 'closed', 'opening_hours': []},
+                            {'dayofweek': 2, 'local_date': '2018-06-12', 'status': 'open',
+                            'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
+                            {'dayofweek': 3, 'local_date': '2018-06-13', 'status': 'open',
+                            'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
+                            {'dayofweek': 4, 'local_date': '2018-06-14', 'status': 'open',
+                            'opening_hours': [{'beginning': '09:30', 'end': '21:45'}]},
+                            {'dayofweek': 5, 'local_date': '2018-06-15', 'status': 'open',
+                            'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
+                            {'dayofweek': 6, 'local_date': '2018-06-16', 'status': 'open',
+                            'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]},
+                            {'dayofweek': 7, 'local_date': '2018-06-17', 'status': 'open',
+                            'opening_hours': [{'beginning': '09:30', 'end': '18:00'}]}
+                        ]
+                    },
+                    {
+                        'international_format': '+33140494814',
+                        'local_format': '+33140494814',
+                        'type': 'phone',
+                        'url': 'tel:+33140494814'
+                    },
+                    {
+                        'type': 'website',
+                        'url': 'http://www.musee-orsay.fr'
+                    }
                 ],
                 'meta': ANY
             }
@@ -329,7 +397,18 @@ def test_single_raw_filter():
                         }
                     ]
                 },
-                'blocks': [],
+                'blocks': [
+                    {
+                        'international_format': '+33 1 42 72 09 37',
+                        'local_format': '+33 1 42 72 09 37',
+                        'type': 'phone',
+                        'url': 'tel:+33 1 42 72 09 37'
+                    },
+                    {
+                        'type': 'website',
+                        'url': 'http://www.paris.catholique.fr/-Notre-Dame-des-Blancs-Manteaux,1290-.html'
+                    }
+                ],
                 'meta': ANY
             }
         ]

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -3,6 +3,8 @@ from app import app
 from apistar.test import TestClient
 from freezegun import freeze_time
 
+from .utils import enable_pj_source
+
 BBOX_PARIS="2.252876,48.819862,2.395707,48.891132"
 BBOX_BREST="-4.807542,48.090743,-4.097541,48.800743"
 INVALID_BBOX_PARIS_LEFT_PERM_RIGHT="2.395707,48.819862,2.252876,48.891132"
@@ -535,6 +537,36 @@ def test_valid_category():
 
     assert response.status_code == 200
 
+    resp = response.json()
+
+    assert resp == {
+        'places': [
+            {
+                'type': 'poi',
+                'id': 'osm:node:36153811',
+                'name': 'Multiplexe Liberté',
+                'local_name': 'Multiplexe Liberté',
+                'class_name': 'cinema',
+                'subclass_name': 'cinema',
+                'geometry': ANY,
+                'address': ANY,
+                'blocks': [],
+                'meta': {'source': 'osm'}
+            }
+        ]
+    }
+
+@enable_pj_source()
+def test_places_with_explicit_source_osm():
+    """
+        If source=osm is passed to the query, pj_source should be ignored
+    """
+    client = TestClient(app)
+    response = client.get(
+        url=f'http://localhost/v1/places?bbox={BBOX_BREST}&category=leisure&source=osm'
+    )
+
+    assert response.status_code == 200
     resp = response.json()
 
     assert resp == {

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -5,17 +5,15 @@ import os
 
 from app import app
 from idunn.api import places
-from idunn.api.pages_jaunes import PjSource
 
-from .utils import override_settings
+from .utils import enable_pj_source
 
 filepath = os.path.join(os.path.dirname(__file__), 'fixtures', 'pj', 'musee_picasso.json')
 musee_picasso = json.load(open(filepath))
 
 
-@override_settings({'PJ_ES': 'http://localhost'})
+@enable_pj_source()
 def test_pj_place():
-    places.pj_source = PjSource()
     with mock.patch.object(places.pj_source.es, 'search',
         new=lambda *x,**y : {"hits": {"hits": [musee_picasso]}}
     ):

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -367,4 +367,4 @@ def test_wrong_verbosity():
         url=f'http://localhost/v1/places/osm:way:63178753?lang=fr&verbosity=shoooooort',
     )
     assert response.status_code == 400
-    assert response._content == b'{"message":"verbosity shoooooort does not belong to the set of possible verbosity values=[\'long\', \'short\']"}'
+    assert "Unknown verbosity" in response.json()['message']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,9 @@ from contextlib import contextmanager
 from copy import deepcopy
 
 from idunn import settings
+from idunn.api import places, places_list
+from idunn.api.pages_jaunes import PjSource
+
 
 @contextmanager
 def override_settings(overrides):
@@ -14,3 +17,16 @@ def override_settings(overrides):
         yield
     finally:
         settings._settings = old_settings
+
+@contextmanager
+def enable_pj_source():
+    old_source = places.pj_source
+    with override_settings({'PJ_ES': 'http://pj_es.test'}):
+        new_source = PjSource()
+        places.pj_source = new_source
+        places_list.pj_source = new_source
+        try:
+            yield
+        finally:
+            places.pj_source = old_source
+            places_list.pj_source = old_source


### PR DESCRIPTION
* `list` verbosity does not contain "information" block (including wikipedia info) contrary to `long`, and is used by default on GET /places?bbox=...
* `source` parameter can be used by the client to force the source selection. Eg: `?source=osm`