### PR TITLE
Optimize opening hours parsing

### DIFF
--- a/idunn/blocks/opening_hour.py
+++ b/idunn/blocks/opening_hour.py
@@ -71,14 +71,17 @@ class OpeningHourBlock(BaseBlock):
 
         poi_tzname = tz.tzNameAt(poi_lat, poi_lon, forceTZ=True)
         poi_tz = get_tz(poi_tzname, poi_lat, poi_lon)
-        poi_location = (poi_lat, poi_lon, poi_tzname, 24)
 
         if poi_tz is None:
             logger.info("No timezone found for poi %s", es_poi.get('id'))
             return None
 
+        hoh_args = {}
+        if any(k in raw for k in ['sunset', 'sunrise', 'dawn', 'dusk']):
+            # Optimization: use astral location only when necessary
+            hoh_args['location'] = (poi_lat, poi_lon, poi_tzname, 24)
         try:
-            oh = hoh.OHParser(raw, location=poi_location)
+            oh = hoh.OHParser(raw, **hoh_args)
         except HOHError:
             logger.info(
                 "Failed to parse opening_hours field, id:'%s' raw:'%s'",

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -57,10 +57,29 @@ class PjPOI(BasePlace):
     def get_raw_opening_hours(self):
         opening_hours_dict = self.get('OpeningHours', {})
         raw = ""
+
+        def format_day_range(first_day, last_day, times):
+            if not times:
+                return ''
+            if first_day == last_day:
+                return f'{first_day} {times}; '
+            return f'{first_day}-{last_day} {times}; '
+
+        first_day, last_day, times = ('', '', '')
         for k in ['Mo','Tu','We','Th','Fr','Sa','Su']:
             value = opening_hours_dict.get(k)
-            if value:
-                raw += f'{k} {value}; '
+            if not value or value != times:
+                raw += format_day_range(first_day, last_day, times)
+                first_day = ''
+                last_day = ''
+                times = ''
+            if value and value != times:
+                first_day = k
+                last_day = k
+                times = value
+            if value and value == times:
+                last_day = k
+        raw += format_day_range(first_day, last_day, times)
         return raw.rstrip('; ')
 
     def get_raw_wheelchair(self):

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -58,4 +58,4 @@ THUMBR_URLS: "https://s1.qwant.com/thumbr,https://s2.qwant.com/thumbr"
 # Pages jaunes
 PJ_ES:
 PJ_ES_INDEX: "pagesjaunes"
-PJ_ES_QUERY_TEMPLATE: "pagesjaunes_bounding_query"
+PJ_ES_QUERY_TEMPLATE: "pagesjaunes_query"

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -38,7 +38,7 @@ def test_pj_place():
 
         blocks = resp['blocks']
         assert blocks[0]['type'] == 'opening_hours'
-        assert blocks[0]['raw'] == "Tu 10:30-18:00; We 10:30-18:00; Th 10:30-18:00; Fr 10:30-18:00; Sa 10:30-18:00; Su 10:30-18:00"
+        assert blocks[0]['raw'] == "Tu-Su 10:30-18:00"
 
         assert blocks[1]['type'] == 'phone'
         assert blocks[1]['url'] == 'tel:+33 185560036'


### PR DESCRIPTION
* solar hours should be computed only when necessary (unfortunately hoh always initializes SolarHours if `location` is set)
* shorter version of raw opening hours in `PjPOI`