### PR TITLE
Fix memory leak and improvements about error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,9 @@ components = [
     PrometheusComponent()
 ]
 
-event_hooks = [LogErrorHook(), CORSHeaders, PrometheusHooks()]
+# WARNING: using Classes (and not instances) in hooks list causes a memory leak.
+# See https://github.com/encode/apistar/issues/606 for more details
+event_hooks = [LogErrorHook(), CORSHeaders(), PrometheusHooks()]
 
 
 app = App(

--- a/idunn/blocks/opening_hour.py
+++ b/idunn/blocks/opening_hour.py
@@ -5,6 +5,7 @@ from apistar import validators, types
 from tzwhere import tzwhere
 import humanized_opening_hours as hoh
 from humanized_opening_hours.exceptions import HOHError
+from lark.exceptions import LarkError
 
 from .base import BaseBlock
 
@@ -82,7 +83,7 @@ class OpeningHourBlock(BaseBlock):
             hoh_args['location'] = (poi_lat, poi_lon, poi_tzname, 24)
         try:
             oh = hoh.OHParser(raw, **hoh_args)
-        except HOHError:
+        except (HOHError, LarkError):
             logger.info(
                 "Failed to parse opening_hours field, id:'%s' raw:'%s'",
                 es_poi.get_id(), raw, exc_info=True
@@ -96,15 +97,19 @@ class OpeningHourBlock(BaseBlock):
         else:
             status = 'closed'
 
-        if is247:
+        if is247 or oh.is_24_7:
             return cls(
                 status=status,
                 next_transition_datetime=None,
                 seconds_before_next_transition=None,
-                is_24_7=is247,
+                is_24_7=True,
                 raw=oh.field,
                 days=cls.get_days(oh, dt=poi_dt)
             )
+
+        if all(r.status == 'closed' for r in oh.rules):
+            # Ignore opening_hours such as "Apr 1-Sep 30: off", causing overflow
+            return None
 
         # The current version of the hoh lib doesn't allow to use the next_change() function
         # with an offset aware datetime.
@@ -127,7 +132,7 @@ class OpeningHourBlock(BaseBlock):
             status=status,
             next_transition_datetime=next_transition_datetime,
             seconds_before_next_transition=time_before_next,
-            is_24_7=is247,
+            is_24_7=oh.is_24_7,
             raw=oh.field,
             days=cls.get_days(oh, dt=poi_dt)
         )

--- a/idunn/blocks/opening_hour.py
+++ b/idunn/blocks/opening_hour.py
@@ -117,7 +117,10 @@ class OpeningHourBlock(BaseBlock):
         try:
             nt = oh.next_change(dt=poi_dt.replace(tzinfo=None))
         except HOHError:
-            logger.info("HOHError: Failed to compute next transition for poi %s", es_poi.get('id'), exc_info=True)
+            logger.info(
+                "HOHError: Failed to compute next transition for poi %s",es_poi.get_id(),
+                exc_info=True
+            )
             return None
 
         # Then we localize the next_change transition datetime in the local POI timezone.

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -81,7 +81,12 @@ class PjPOI(BasePlace):
             if value and value == times:
                 last_day = k
         raw += format_day_range(first_day, last_day, times)
-        return raw.rstrip('; ')
+        result = raw.rstrip('; ')
+
+        if result == 'Mo-Su 24/7':
+            return '24/7'
+
+        return result
 
     def get_raw_wheelchair(self):
         return self.get('WheelchairAccessible')

--- a/idunn/utils/logging.py
+++ b/idunn/utils/logging.py
@@ -31,7 +31,9 @@ def init_logging(settings: Settings):
     # we set this handler to the main logger
     logging.getLogger().handlers = [logHandler]
 
+
 class LogErrorHook:
-    def on_error(self, response: http.Response):
+    def on_error(self, request: http.Request):
         prometheus.exception("unhandled_error")
-        logging.getLogger('idunn.error').exception("An unhandled error was raised")
+        logging.getLogger('idunn.error')\
+            .exception("An unhandled error was raised.", extra={'url': request.url})

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -1,3 +1,4 @@
+import pytest
 from freezegun import freeze_time
 from unittest.mock import ANY
 from idunn.blocks.opening_hour import OpeningHourBlock
@@ -386,3 +387,31 @@ def test_opening_hour_2_years():
         raw='Oct-Mar 07:30-19:30; Apr-Sep 07:00-21:00',
         days=ANY
     )
+
+@freeze_time("2019-07-01T08:00:00")
+def test_oh_with_only_closed_rules():
+    oh_block = get_moscow_poi("Apr 1-Sep 30: off")
+    assert oh_block is None
+
+@freeze_time("2019-07-01T08:00:00")
+def test_oh_24_7_variant():
+    oh_block = get_moscow_poi("Apr 1-Sep 30: off")
+    assert oh_block is None
+
+@freeze_time("2019-07-01T08:00:00")
+def test_unsupported_rule_raises_no_exception():
+    oh_block = get_moscow_poi(
+        "Nov 3-Apr 30: 08:00-17:00; May 2-Nov 2: 08:00-17:30;"
+        "Jul 14 off; May 1 off; PH 12:30-13:30 off"
+    )
+    assert oh_block is None
+
+@pytest.mark.skip(
+    "Fix depending on https://github.com/rezemika/humanized_opening_hours/pull/35"
+)
+@freeze_time("2019-07-01T08:00:00")
+def test_oh_all_rules_in_the_past():
+    oh_block = get_moscow_poi(
+        "2018 Jul 02- 2018 Sep 02 Mo-Su 08:00-20:00"
+    )
+    assert oh_block is None


### PR DESCRIPTION
* Fix memory leak in event_hooks
* Catch parser error (`LarkError`) that are sometimes not caught by hoh library
* Parse variants of "24/7" opening hours correctly
* Add request URL to "unhandled error" object