### PR TITLE
Validate URLs with float, fix bug in apistar injector

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,11 @@
-from apistar import App, Include
+from apistar import Include
 
 from idunn import settings
 from idunn.utils.index_names import IndexNamesSettingsComponent
 from idunn.utils.es_wrapper import ElasticSearchComponent
 from idunn.utils.logging import init_logging, LogErrorHook
 from idunn.utils.cors import CORSHeaders
+from idunn.utils.app import IdunnApp
 from idunn.api.urls import get_api_urls
 from apistar_prometheus import PrometheusComponent, PrometheusHooks
 
@@ -26,7 +27,7 @@ components = [
 event_hooks = [LogErrorHook(), CORSHeaders(), PrometheusHooks()]
 
 
-app = App(
+app = IdunnApp(
     routes=routes,
     schema_url='/schema',
     components=components,

--- a/idunn/api/closest.py
+++ b/idunn/api/closest.py
@@ -29,7 +29,6 @@ def get_closest_place(lat: float, lon: float, es: Elasticsearch):
 
 
 def closest_address(lat: float, lon: float, es: Elasticsearch, lang=None, verbosity=DEFAULT_VERBOSITY) -> Address:
-    """Main handler that returns the requested place"""
     if verbosity not in ALL_VERBOSITY_LEVELS:
         raise BadRequest({
             "message": f"Unknown verbosity '{verbosity}'. Accepted values are {ALL_VERBOSITY_LEVELS}"

--- a/idunn/api/places.py
+++ b/idunn/api/places.py
@@ -51,7 +51,7 @@ def get_place(id, es: Elasticsearch, indices: IndexNames, lang=None, type=None, 
     return loader(es_place['_source']).load_place(lang, verbosity)
 
 
-def get_place_latlon(lat, lon, es: Elasticsearch, lang=None, verbosity=DEFAULT_VERBOSITY) -> Place:
+def get_place_latlon(lat: float, lon: float, es: Elasticsearch, lang=None, verbosity=DEFAULT_VERBOSITY) -> Place:
     verbosity = validate_verbosity(verbosity)
     lang = validate_lang(lang)
     try:

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -22,11 +22,21 @@ def get_api_urls(settings):
     return [
         Route('/metrics', 'GET', handler=metric_handler),
         Route('/status', 'GET', handler=get_status),
+
+        # Deprecated
         Route('/pois/{id}', 'GET', handler=get_poi),
-        Route('/places/latlon:{lat}:{lon}', 'GET', handler=get_place_latlon),
+
+        # Werkzeug syntax is used to allow negative floats
+        Route('/places/latlon:<float(signed=True):lat>:<float(signed=True):lon>', 'GET', handler=get_place_latlon),
         Route('/places/{id}', 'GET', handler=get_place),
+
         Route('/categories', 'GET', handler=get_all_categories),
+
         Route('/places', 'GET', handler=get_places_bbox),
-        Route('/reverse/{lat}:{lon}', 'GET', handler=closest_address),
+
+        # Werkzeug syntax is used to allow negative floats
+        Route('/reverse/<float(signed=True):lat>:<float(signed=True):lon>', 'GET', handler=closest_address),
+
+        # Kuzzle events
         Route('/events', 'GET', handler=get_events_bbox),
     ]

--- a/idunn/utils/app.py
+++ b/idunn/utils/app.py
@@ -1,0 +1,59 @@
+from apistar import App
+
+class IdunnApp(App):
+    def __call__(self, environ, start_response):
+        def get_default_state():
+            return {
+                'environ': environ,
+                'start_response': start_response,
+                'exc': None,
+                'app': self,
+                'path_params': None,
+                'route': None,
+                'response': None,
+            }
+
+        state = get_default_state()
+        method = environ['REQUEST_METHOD'].upper()
+        path = environ['PATH_INFO']
+
+        if self.event_hooks is None:
+            on_request, on_response, on_error = [], [], []
+        else:
+            on_request, on_response, on_error = self.get_event_hooks()
+
+        try:
+            route, path_params = self.router.lookup(path, method)
+            state['route'] = route
+            state['path_params'] = path_params
+            if route.standalone:
+                funcs = [route.handler]
+            else:
+                funcs = (
+                    on_request +
+                    [route.handler, self.render_response] +
+                    on_response +
+                    [self.finalize_wsgi]
+                )
+            return self.injector.run(funcs, state)
+        except Exception as exc:
+            # This is the only change with the parent class.
+            # The `state` that caused the exception is not reused
+            # to avoid polluting the injector cache
+            # with partial dependency resolution.
+            state = get_default_state()
+            try:
+                state['exc'] = exc
+                funcs = (
+                    [self.exception_handler] +
+                    on_response +
+                    [self.finalize_wsgi]
+                )
+                return self.injector.run(funcs, state)
+            except Exception as inner_exc:
+                try:
+                    state['exc'] = inner_exc
+                    self.injector.run(on_error, state)
+                finally:
+                    funcs = [self.error_handler, self.finalize_wsgi]
+                    return self.injector.run(funcs, state)

--- a/idunn/utils/app.py
+++ b/idunn/utils/app.py
@@ -41,19 +41,26 @@ class IdunnApp(App):
             # The `state` that caused the exception is not reused
             # to avoid polluting the injector cache
             # with partial dependency resolution.
-            state = get_default_state()
+            exc_state = get_default_state()
+            exc_state['exc'] = exc
+            if 'route' in state:
+                exc_state['route'] = state['route']
+            if 'path_params' in state:
+                exc_state['path_params'] = state['path_params']
+            return self.handle_request_exception(exc_state, on_response, on_error)
+
+    def handle_request_exception(self, state, on_response, on_error):
+        try:
+            funcs = (
+                [self.exception_handler] +
+                on_response +
+                [self.finalize_wsgi]
+            )
+            return self.injector.run(funcs, state)
+        except Exception as inner_exc:
             try:
-                state['exc'] = exc
-                funcs = (
-                    [self.exception_handler] +
-                    on_response +
-                    [self.finalize_wsgi]
-                )
+                state['exc'] = inner_exc
+                self.injector.run(on_error, state)
+            finally:
+                funcs = [self.error_handler, self.finalize_wsgi]
                 return self.injector.run(funcs, state)
-            except Exception as inner_exc:
-                try:
-                    state['exc'] = inner_exc
-                    self.injector.run(on_error, state)
-                finally:
-                    funcs = [self.error_handler, self.finalize_wsgi]
-                    return self.injector.run(funcs, state)

--- a/idunn/utils/prometheus.py
+++ b/idunn/utils/prometheus.py
@@ -1,7 +1,5 @@
-import time
 import contextlib
 
-from apistar import Component
 from prometheus_client import Counter, Gauge, Histogram
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,3 +148,13 @@ def test_services_and_information():
 	}
     ]
 
+def test_exc_scenario():
+    """
+    A scenario with 2 consecutive requests that used to cause unhandled errors
+    because of a bug in Apistar injector.
+    """
+    client = TestClient(app)
+    response = client.get('http://localhost/v1/places?bbox=-0.3,49.2,8.1,55.5&size=52&category=bar&lang=fr')
+    assert response.status_code == 400
+    response = client.get('http://localhost/v1/abcdef')
+    assert response.status_code == 404

--- a/tests/test_closest.py
+++ b/tests/test_closest.py
@@ -11,6 +11,10 @@ def test_reverse():
     assert response.json()['id'] == 'addr:5.108632;48.810273'
     assert response.json()['name'] == '4 Rue du Moulin'
 
+def test_reverse_invalid():
+    client = TestClient(app)
+    response = client.get('http://localhost/v1/reverse/48.810273:abc')
+    assert response.status_code == 404
 
 def test_place_latlon():
     client = TestClient(app)
@@ -34,3 +38,8 @@ def test_place_latlon_no_address():
     assert response_data['name'] == '-48.81027 : 35.10863'
     assert response_data['geometry']['center'] == [35.10863, -48.81027]
     assert response_data['address'] is None
+
+def test_place_latlon_invalid():
+    client = TestClient(app)
+    response = client.get('http://localhost/v1/places/latlon:abc:55-')
+    assert response.status_code == 404


### PR DESCRIPTION
* Validate float values, and accept negative values using werkzeug syntax https://werkzeug.palletsprojects.com/en/0.15.x/routing/#werkzeug.routing.FloatConverter
* Work around bug in apistar that may cause the injector cache to be polluted with incomplete dependency resolution. Fixed using a custom `IdunnApp` class.