### PR TITLE
Fix boolean setting value set by environment

### DIFF
--- a/idunn/utils/settings.py
+++ b/idunn/utils/settings.py
@@ -64,13 +64,13 @@ class SettingsComponent(Component):
         eg. IDUNN_ES to override the "ES" settings in the IDUNN project.
         """
         for k in self._settings.keys():
-            overriden_value = os.environ.get(f'{project_name}_{k}')
-            if overriden_value:
-                if overriden_value.lower() == 'true':
-                    overriden_value = True
-                if overriden_value.lower() == 'false':
-                    overriden_value = False
-                self._settings[k] = overriden_value
+            overridden_value = os.environ.get(f'{project_name}_{k}')
+            if overridden_value:
+                if overridden_value.lower() == 'true':
+                    overridden_value = True
+                elif overridden_value.lower() == 'false':
+                    overridden_value = False
+                self._settings[k] = overridden_value
 
     def can_handle_parameter(self, parameter: Parameter) -> bool:
         # Micro-optimization given that we know that this component


### PR DESCRIPTION
Overriding a setting value with `true` string in environment variable was broken because of two consecutive `if`.