### PR TITLE
combigo: Fix transport info in walk steps

### DIFF
--- a/idunn/directions/models.py
+++ b/idunn/directions/models.py
@@ -39,8 +39,8 @@ class RouteManeuver(BaseModel):
 class TransportInfo(BaseModel):
     num: Optional[str]
     direction: Optional[str]
-    lineColor: str
-    network: str
+    lineColor: Optional[str]
+    network: Optional[str]
 
 
 class TransportStop(BaseModel):

--- a/tests/fixtures/directions/combigo_directions_publictransport.json
+++ b/tests/fixtures/directions/combigo_directions_publictransport.json
@@ -964,7 +964,8 @@
           "type": "WALK",
           "action": "Se diriger vers le sud sur le boulevard Beaumarchais",
           "infos": {
-            "maneuverType": "depart"
+            "maneuverType": "depart",
+            "num": "D 186"
           },
           "shapes": [
             [


### PR DESCRIPTION
All fields in `TransportInfo` are now optional to handle "num" in "walk" steps.