### PR TITLE
places: Fallback to street name and label when address is not defined

### DIFF
--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -88,15 +88,16 @@ class BasePlace(dict):
         name = raw_address.get("name")
         housenumber = raw_address.get("house_number")
         label = raw_address.get("label")
+        street = self.build_street()
 
         return {
             "id": id,
-            "name": name,
+            "name": name or street.get('name'),
             "housenumber": housenumber,
             "postcode": postcodes,
-            "label": label,
+            "label": label or street.get('label'),
             "admin": self.build_admin(lang),
-            "street": self.build_street(),
+            "street": street,
             "admins": self.build_admins(),
         }
 

--- a/tests/fixtures/street_birnenweg.json
+++ b/tests/fixtures/street_birnenweg.json
@@ -90,9 +90,9 @@
 		"lon": 10.6646915
 	},
 	"id": "35460343",
-	"label": "9a Birnenweg (Label)",
-	"name": "9a Birnenweg",
-	"street_name": "9a Birnenweg",
+	"label": "Birnenweg (Label)",
+	"name": "Birnenweg",
+	"street_name": "Birnenweg",
 	"weight": 0.0,
 	"zip_codes": ["77777"]
 }

--- a/tests/test_closest.py
+++ b/tests/test_closest.py
@@ -28,6 +28,15 @@ def test_place_latlon():
     assert response_data['address']['label'] == "4 Rue du Moulin (Val-d'Ornain)"
 
 
+def test_place_latlon_with_street_as_closest_address():
+    client = TestClient(app)
+    response = client.get('http://localhost/v1/places/latlon:53.8478:10.6646915')
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data['id'] == 'latlon:53.84780:10.66469'
+    assert response_data['address']['label'] == "Birnenweg (Label)"
+
 def test_place_latlon_no_address():
     client = TestClient(app)
     response = client.get('http://localhost/v1/places/latlon:-48.810273:35.108632')

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -76,8 +76,8 @@ def test_full_query_street():
     assert resp == {
         "type": "street",
         "id": "35460343",
-        "name": "9a Birnenweg",
-        "local_name": "9a Birnenweg",
+        "name": "Birnenweg",
+        "local_name": "Birnenweg",
         "class_name": "street",
         "subclass_name": "street",
         "geometry": {
@@ -88,14 +88,14 @@ def test_full_query_street():
         "address": {
             "admin": None,
             "id": None,
-            "label": None,
-            "name": None,
+            "label": "Birnenweg (Label)",
+            "name": "Birnenweg",
             "housenumber": None,
             "postcode": "77777",
             "street": {
                 "id": '35460343',
-                "name": '9a Birnenweg',
-                "label": '9a Birnenweg (Label)',
+                "name": 'Birnenweg',
+                "label": 'Birnenweg (Label)',
                 "postcodes": ["77777"]
             },
             "admins": [
@@ -281,7 +281,7 @@ def test_type_query_street():
     resp = response.json()
 
     assert resp["id"] == "35460343"
-    assert resp["name"] == "9a Birnenweg"
+    assert resp["name"] == "Birnenweg"
 
 def test_type_query_address():
     client = TestClient(app)


### PR DESCRIPTION
Use street name and label in `address` object as fallback.  
This is especially useful for `latlon` places where the API may return both an address or a street, depending on what is found on reverse search.

NB: For clarity, a street name is renamed in fixtures files. "9a Birnenweg" looks too much like an address.