### PR TITLE
Define reusable circuit breaker

### DIFF
--- a/idunn/utils/circuit_breaker.py
+++ b/idunn/utils/circuit_breaker.py
@@ -1,0 +1,28 @@
+import pybreaker
+import logging
+from requests import HTTPError
+
+from idunn import settings
+
+logger = logging.getLogger(__name__)
+
+def is_http_client_error(exc):
+    return isinstance(exc, HTTPError) \
+        and exc.response is not None \
+        and 400 <= exc.response.status_code < 500
+
+class LogListener(pybreaker.CircuitBreakerListener):
+    def state_change(self, cb, old_state, new_state):
+        msg = "State Change: CB: {0}, From: {1} to New State: {2}".format(cb.name, old_state, new_state)
+        logger.warning(msg)
+
+
+class IdunnCircuitBreaker(pybreaker.CircuitBreaker):
+    def __init__(self, name):
+        super().__init__(
+            fail_max=settings['CIRCUIT_BREAKER_MAXFAIL'],
+            reset_timeout=settings['CIRCUIT_BREAKER_TIMEOUT'],
+            exclude=[is_http_client_error],
+            listeners=[LogListener()],
+            name=name
+        )

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -9,9 +9,6 @@ WIKI_USER_AGENT: "Idunn/0.1" # Used in requests to external wiki* APIs
 
 DEFAULT_LANGUAGE: 'en' # Fallback when no 'lang' in request
 
-WIKI_API_CIRCUIT_TIMEOUT: 120 # seconds
-WIKI_API_CIRCUIT_MAXFAIL: 50
-
 ES_WIKI_LANG: "de,en,es,fr,it" # the (comma separated) list of languages existing in the WIKI_ES
 
 WIKI_API_RL_MAX_CALLS: 100 # Max number of external calls allowed by the rate limiter
@@ -48,6 +45,10 @@ WIKI_DESC_MAX_SIZE: 325 # max size allowed to the description of the wiki block
 
 LIST_PLACES_MAX_SIZE: 50
 
+########################
+## Circuit Breaker
+CIRCUIT_BREAKER_TIMEOUT: 120 # timeout period in seconds
+CIRCUIT_BREAKER_MAXFAIL: 20 # consecutive failures before breaking
 
 
 ########################

--- a/tests/test_api_circuit_breaker.py
+++ b/tests/test_api_circuit_breaker.py
@@ -3,9 +3,8 @@ import pytest
 import responses
 from app import app
 from time import sleep
-from freezegun import freeze_time
 from apistar.test import TestClient
-from idunn.blocks.wikipedia import WikipediaBreaker
+from idunn.blocks.wikipedia import WikipediaSession
 
 @pytest.fixture()
 def breaker_test():
@@ -15,7 +14,7 @@ def breaker_test():
     any waste of time with real timeout and
     failmax
     """
-    wiki_breaker = WikipediaBreaker.get_breaker()
+    wiki_breaker = WikipediaSession.circuit_breaker
     wiki_breaker.fail_max = 3
     wiki_breaker.reset_timeout = 1
     wiki_breaker.close()

--- a/tests/test_wiki_size_limit.py
+++ b/tests/test_wiki_size_limit.py
@@ -4,15 +4,11 @@ import responses
 import pytest
 
 from .utils import override_settings
-from idunn.blocks.wikipedia import SizeLimiter
 
 @pytest.fixture(scope="function")
 def wiki_max_size():
     with override_settings({'WIKI_DESC_MAX_SIZE': 10}):
-        SizeLimiter._max_wiki_desc_size = None
         yield
-    SizeLimiter._max_wiki_desc_size = None
-
 
 @pytest.fixture(scope='module', autouse=True)
 def mock_long_wikipedia_response():


### PR DESCRIPTION
The existing circuit breaker was implemented specifically for Wikipedia APIs. 

This PR defines a new `IdunnCircuitBreaker` that will be reused for all external APIs (weather, etc.)