### PR TITLE
Refactor rate limiter and define limits on directions endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: "--workers=4"
     environment:
      - IDUNN_MIMIR_ES=
-     - IDUNN_WIKI_API_REDIS_URL=idunn-redis:6379
+     - IDUNN_REDIS_URL=redis://idunn-redis:6379
      - IDUNN_LOG_JSON=1
 
   idunn-redis:

--- a/idunn/api/directions.py
+++ b/idunn/api/directions.py
@@ -1,9 +1,19 @@
-from apistar.http import QueryParams
+from apistar.http import QueryParams, Request
 from apistar.exceptions import BadRequest
+
+from idunn import settings
+from idunn.utils.rate_limiter import IdunnRateLimiter
 from ..directions.client import directions_client
 
+rate_limiter = IdunnRateLimiter(
+    resource='idunn.api.directions',
+    max_requests=int(settings['DIRECTIONS_RL_MAX_REQUESTS']),
+    expire=int(settings['DIRECTIONS_RL_EXPIRE'])
+)
 
-def get_directions(f_lon, f_lat, t_lon, t_lat, params: QueryParams):
+def get_directions(f_lon, f_lat, t_lon, t_lat, params: QueryParams, request: Request):
+    rate_limiter.check_limit_per_client(request)
+
     from_position = (f_lon, f_lat)
     to_position = (t_lon, t_lat)
     params_dict = dict(params)
@@ -13,6 +23,6 @@ def get_directions(f_lon, f_lat, t_lon, t_lat, params: QueryParams):
     if not mode:
         raise BadRequest('"type" query param is required')
 
-    return directions_client.get_directions(from_position, to_position,
-        mode=mode, lang=lang
+    return directions_client.get_directions(
+        from_position, to_position, mode=mode, lang=lang
     )

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -14,7 +14,6 @@ ES_WIKI_LANG: "de,en,es,fr,it" # the (comma separated) list of languages existin
 WIKI_API_RL_MAX_CALLS: 100 # Max number of external calls allowed by the rate limiter
 WIKI_API_RL_PERIOD: 1 # Duration (in seconds) of the period where no more than the max number of external calls are expected
 WIKI_API_REDIS_URL: # DEPRECATED. Use REDIS_URL instead
-WIKI_API_REDIS_DB: 0
 WIKI_CACHE_REDIS_DB: 1
 WIKI_CACHE_TIMEOUT: 86400 # seconds
 

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -13,10 +13,9 @@ ES_WIKI_LANG: "de,en,es,fr,it" # the (comma separated) list of languages existin
 
 WIKI_API_RL_MAX_CALLS: 100 # Max number of external calls allowed by the rate limiter
 WIKI_API_RL_PERIOD: 1 # Duration (in seconds) of the period where no more than the max number of external calls are expected
-WIKI_API_REDIS_URL: # URL of the Redis service used by the rate limiter of the Wikipedia API calls
+WIKI_API_REDIS_URL: # DEPRECATED. Use REDIS_URL instead
 WIKI_API_REDIS_DB: 0
 WIKI_CACHE_REDIS_DB: 1
-WIKI_REDIS_TIMEOUT: 1 # seconds
 WIKI_CACHE_TIMEOUT: 86400 # seconds
 
 LOG_LEVEL_BY_MODULE: '{"": "info", "elasticsearch": "warning"}' # json config to set, for each module a log level
@@ -46,9 +45,19 @@ WIKI_DESC_MAX_SIZE: 325 # max size allowed to the description of the wiki block
 LIST_PLACES_MAX_SIZE: 50
 
 ########################
+## Redis
+REDIS_URL:
+REDIS_TIMEOUT: "0.3" # seconds
+
+
+########################
 ## Circuit Breaker
 CIRCUIT_BREAKER_TIMEOUT: 120 # timeout period in seconds
 CIRCUIT_BREAKER_MAXFAIL: 20 # consecutive failures before breaking
+
+########################
+## Rate Limiter
+RATE_LIMITER_REDIS_DB: 0
 
 
 ########################
@@ -83,6 +92,8 @@ CORS_OPTIONS_REQUESTS_ENABLED: False
 
 #######################
 ## Directions
+DIRECTIONS_RL_MAX_REQUESTS: 30 # per client
+DIRECTIONS_RL_EXPIRE: 60 # seconds
 DIRECTIONS_TIMEOUT: 8 # seconds
 QWANT_DIRECTIONS_API_BASE_URL:
 MAPBOX_DIRECTIONS_API_BASE_URL: "https://api.mapbox.com/directions/v5/mapbox"

--- a/idunn/utils/rate_limiter.py
+++ b/idunn/utils/rate_limiter.py
@@ -1,0 +1,68 @@
+import logging
+from apistar.exceptions import HTTPException
+from contextlib import contextmanager
+from redis import RedisError
+from redis_rate_limit import RateLimiter, TooManyRequests
+from idunn.utils.redis import get_redis_pool, RedisNotConfigured
+from idunn import settings
+
+logger = logging.getLogger(__name__)
+
+TooManyRequestsException = TooManyRequests
+
+@contextmanager
+def dummy_limit():
+    yield
+
+class HTTPTooManyRequests(HTTPException):
+    default_status_code = 429
+    default_detail = 'Too Many Requests'
+
+class IdunnRateLimiter:
+    def __init__(self, resource, max_requests, expire):
+        try:
+            redis_pool = get_redis_pool(db=settings['RATE_LIMITER_REDIS_DB'])
+        except RedisNotConfigured:
+            logger.warning("Redis URL not configured: rate limiter not started")
+            self._limiter = None
+        else:
+            """
+            If a redis is configured,
+            then we use the corresponding redis
+            service in the rate limiter.
+            """
+            self._limiter = RateLimiter(
+                resource=resource,
+                max_requests=max_requests,
+                expire=expire,
+                redis_pool=redis_pool
+            )
+
+    def limit(self, client, ignore_redis_error=False):
+        if self._limiter is None:
+            return dummy_limit()
+
+        @contextmanager
+        def limit():
+            try:
+                with self._limiter.limit(client):
+                    yield
+            except RedisError as e:
+                if ignore_redis_error:
+                    logger.warning(
+                        'Ignoring RedisError in rate limiter for %s',
+                        self._limiter.resource, exc_info=True
+                    )
+                    yield
+                else:
+                    raise
+
+        return limit()
+
+    def check_limit_per_client(self, request):
+        client_id = request.headers.get('x-client-hash') or 'default'
+        try:
+            with self.limit(client=client_id, ignore_redis_error=True):
+                pass
+        except TooManyRequestsException:
+            raise HTTPTooManyRequests

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -16,10 +16,10 @@ def cache_test_normal(redis):
     We define here settings specific to the
     test of the Wikipedia/Wikidata cache
     """
-    settings._settings['WIKI_API_REDIS_URL'] = redis
+    settings._settings['REDIS_URL'] = redis
     WikipediaCache._connection = None
     yield
-    settings._settings['WIKI_API_REDIS_URL'] = None
+    settings._settings['REDIS_URL'] = None
     WikipediaCache._connection = None
 
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -24,7 +24,7 @@ def limiter_test_normal(redis, disable_wikipedia_cache):
     We define low max calls limits to avoid
     too large number of requests made
     """
-    with override_settings({'WIKI_API_RL_PERIOD': 5, 'WIKI_API_RL_MAX_CALLS': 6, 'WIKI_API_REDIS_URL': redis}):
+    with override_settings({'WIKI_API_RL_PERIOD': 5, 'WIKI_API_RL_MAX_CALLS': 6, 'REDIS_URL': redis}):
         # To force settings overriding we need to set to None the limiter
         WikipediaSession._rate_limiter = None
         yield
@@ -38,7 +38,7 @@ def limiter_test_interruption(redis, disable_wikipedia_cache):
     allowed by the fixture 'limiter_test_normal'
     So we need another specific fixture.
     """
-    with override_settings({'WIKI_API_RL_PERIOD': 5, 'WIKI_API_RL_MAX_CALLS': 100, 'WIKI_API_REDIS_URL': redis}):
+    with override_settings({'WIKI_API_RL_PERIOD': 5, 'WIKI_API_RL_MAX_CALLS': 100, 'REDIS_URL': redis}):
         WikipediaSession._rate_limiter = None
         yield
     WikipediaSession._rate_limiter = None
@@ -159,7 +159,7 @@ def restart_wiki_redis(docker_services):
     del docker_services._services['wiki_redis']
     port = docker_services.port_for("wiki_redis", 6379)
     url = f'{docker_services.docker_ip}:{port}'
-    settings._settings['WIKI_API_REDIS_URL'] = url
+    settings._settings['REDIS_URL'] = url
     WikipediaSession._rate_limiter = None
 
 def test_rate_limiter_with_redisError(limiter_test_interruption, mock_wikipedia, monkeypatch):


### PR DESCRIPTION
* Define a new class `IdunnRateLimiter` using the existing mechanism (based on redis_rate_limit).
* Implement a limit per client, based on request headers
* Add an option to ignore Redis errors (not ideal, that will do for now, in order to reuse existing idunn-redis service)
