### PR TITLE
Fix kuzzle tests with FastAPI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from idunn import settings
 from idunn.utils.logging import init_logging, handle_errors
 from idunn.api.urls import get_api_urls
+from idunn.utils.encoders import override_datetime_encoder
 
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -38,7 +39,7 @@ async def validation_exception_handler(request, exc):
 
 app.add_middleware(PrometheusMiddleware)
 app.add_exception_handler(Exception, handle_errors)
-
+override_datetime_encoder()
 
 if __name__ == '__main__':
     uvicorn.run(app, host="127.0.0.1", port=5000, log_level="debug")

--- a/idunn/api/places_list.py
+++ b/idunn/api/places_list.py
@@ -123,10 +123,12 @@ class PlacesQueryParam(CommonQueryParam):
 
 
 class EventQueryParam(CommonQueryParam):
-    category: str
+    category: Optional[str]
 
     @validator('category', pre=True, always=True)
     def valid_categories(cls, v):
+        if v is None:
+            return None
         if v not in ALL_OUTING_CATEGORIES:
             raise ValueError(f"outing_types \'{v}\' is invalid since it does not belong to set of possible outings type: {list(ALL_OUTING_CATEGORIES.keys())}")
         else:
@@ -213,7 +215,7 @@ def get_places_bbox(
 
 def get_events_bbox(
     bbox: str,
-    category: str = Query(None),
+    category: Optional[str] = Query(None),
     size: int = Query(None),
     lang: Optional[str] = Query(None),
     verbosity: Optional[str] = Query(None),

--- a/idunn/utils/encoders.py
+++ b/idunn/utils/encoders.py
@@ -1,0 +1,12 @@
+from datetime import datetime, timezone
+from pydantic.json import ENCODERS_BY_TYPE
+
+def override_datetime_encoder():
+    default_datetime_formatter = ENCODERS_BY_TYPE[datetime]
+
+    def custom_dt_formatter(dt):
+        if dt.tzinfo == timezone.utc:
+            return default_datetime_formatter(dt).replace('+00:00', 'Z')
+        return default_datetime_formatter(dt)
+
+    ENCODERS_BY_TYPE[datetime] = custom_dt_formatter

--- a/tests/test_kuzzle.py
+++ b/tests/test_kuzzle.py
@@ -29,45 +29,45 @@ def test_kuzzle_event_ok():
         )
 
         # TODO (none found, might be because of the mock)
-        # assert len(rsps.calls) == 1
+        assert len(rsps.calls) == 1
 
-        # resp = response.json()
-        # firstEventData = resp['events'][0]
+        resp = response.json()
+        firstEventData = resp['events'][0]
 
-        # assert firstEventData['id'] == 'event:openagenda_92106271'
-        # assert firstEventData['name'] == "Quand les livres expliquent la science"
-        # assert firstEventData['local_name'] == "Quand les livres expliquent la science"
-        # assert firstEventData['class_name'] == 'event'
-        # assert firstEventData['subclass_name'] == 'event'
-        # assert firstEventData['address']['name'] == 'Cité des Sciences et de l\'Industrie'
-        # assert firstEventData['address']['label'] == '30 Avenue Corentin Cariou, Paris'
-        # assert firstEventData['address']['city'] == 'Paris'
-        # assert firstEventData['blocks'][0]['type'] == 'event_opening_dates'
-        # assert firstEventData['blocks'][1]['type'] == 'event_description'
-        # assert firstEventData['blocks'][2]['type'] == 'website'
-        # assert firstEventData['blocks'][3]['type'] == 'images'
-        # assert firstEventData['blocks'][0]['date_start'] == '2019-03-23T00:00:00Z'
-        # assert firstEventData['blocks'][3]['images'] == [
-        #     {
-        #         "url": "https://s2.qwant.com/thumbr/0x0/3/a/0639adb03540e9f45abb5a27668ac04d6f964aa30d99fa0275756d3d2b413b/evtbevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg?u=http%3A%2F%2Fcibul.s3.amazonaws.com%2Fevtbevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg&q=0&b=1&p=0&a=0",
-        #         "alt": "Quand les livres expliquent la science",
-        #         "credits": "",
-        #         "source_url": "http://cibul.s3.amazonaws.com/evtbevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg"
-        #     },
-        #     {
-        #         "url": "https://s2.qwant.com/thumbr/0x0/7/f/c091d2d95f56f07beb1a2cd1c61f4d01a7ea4ab5079ab81b379baed315a48f/event_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg?u=http%3A%2F%2Fcibul.s3.amazonaws.com%2Fevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg&q=0&b=1&p=0&a=0",
-        #         "alt": "Quand les livres expliquent la science",
-        #         "credits": "",
-        #         "source_url": "http://cibul.s3.amazonaws.com/event_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg"
-        #     }
-        # ]
+        assert firstEventData['id'] == 'event:openagenda_92106271'
+        assert firstEventData['name'] == "Quand les livres expliquent la science"
+        assert firstEventData['local_name'] == "Quand les livres expliquent la science"
+        assert firstEventData['class_name'] == 'event'
+        assert firstEventData['subclass_name'] == 'event'
+        assert firstEventData['address']['name'] == 'Cité des Sciences et de l\'Industrie'
+        assert firstEventData['address']['label'] == '30 Avenue Corentin Cariou, Paris'
+        assert firstEventData['address']['city'] == 'Paris'
+        assert firstEventData['blocks'][0]['type'] == 'event_opening_dates'
+        assert firstEventData['blocks'][1]['type'] == 'event_description'
+        assert firstEventData['blocks'][2]['type'] == 'website'
+        assert firstEventData['blocks'][3]['type'] == 'images'
+        assert firstEventData['blocks'][0]['date_start'] == '2019-03-23T00:00:00Z'
+        assert firstEventData['blocks'][3]['images'] == [
+            {
+                "url": "https://s2.qwant.com/thumbr/0x0/3/a/0639adb03540e9f45abb5a27668ac04d6f964aa30d99fa0275756d3d2b413b/evtbevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg?u=http%3A%2F%2Fcibul.s3.amazonaws.com%2Fevtbevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg&q=0&b=1&p=0&a=0",
+                "alt": "Quand les livres expliquent la science",
+                "credits": "",
+                "source_url": "http://cibul.s3.amazonaws.com/evtbevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg"
+            },
+            {
+                "url": "https://s2.qwant.com/thumbr/0x0/7/f/c091d2d95f56f07beb1a2cd1c61f4d01a7ea4ab5079ab81b379baed315a48f/event_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg?u=http%3A%2F%2Fcibul.s3.amazonaws.com%2Fevent_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg&q=0&b=1&p=0&a=0",
+                "alt": "Quand les livres expliquent la science",
+                "credits": "",
+                "source_url": "http://cibul.s3.amazonaws.com/event_conference-casse-croute-le-fonds-ancien-de-la-mediatheque-centre-ville_347092.jpg"
+            }
+        ]
 
 
-        # """
-        # We check that there is no Wikipedia block
-        # in the answer
-        # """
-        # assert all(b['type'] != "wikipedia" for b in firstEventData['blocks'])
+        """
+        We check that there is no Wikipedia block
+        in the answer
+        """
+        assert all(b['type'] != "wikipedia" for b in firstEventData['blocks'])
 
 
 def test_kuzzle_event_nok():


### PR DESCRIPTION
Besides tweaking the parameters validation, it is also necessary to define a custom formatter for datetimes, in order to preserve the same format.