### PR TITLE
Debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The main endpoints are:
     * `size`: maximum number of places in the response
     * `verbosity`: default verbosity is `list` (equivalent to `long`, except "information" and "wiki" blocks are not returned)
     * `source`: (optional) to force a data source (instead of automated selection based on coverage). Accepted values: `osm`, `pages_jaunes`
-    * `q`: full-text query (optional, experimental) 
+    * `q`: full-text query (optional, experimental)
 * `/v1/places?bbox={bbox}&raw_filter=class,subclass&size={size}` to get a list of all points of interest matching the given bbox (=left,bot,right,top e.g. `bbox=2,48,3,49`) and the raw filters (e.g. `raw_filter=*,restaurant&raw_filter=shop,*&raw_filter=bakery,bakery`)
 * `/v1/categories` to get the list of all the categories you can filter on.
 * `/v1/pois/{poi_id}?lang={lang}` is the **deprecated** route to get the details of a POI.
@@ -51,6 +51,10 @@ pipenv install
 - and then:
 ```shell
 IDUNN_MIMIR_ES=<url_to_MIMIR_ES> IDUNN_WIKI_ES=<url_to_WIKI_ES> pipenv run python app.py
+```
+- **If** you want to connect to a specific MIMIR_ES environment behind https for debug purpose, you can add this env variable:
+```shell
+IDUNN_DEBUG=True
 ```
 - you can query the API on port 5000:
 ```shell

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -100,3 +100,8 @@ MAPBOX_DIRECTIONS_API_BASE_URL: "https://api.mapbox.com/directions/v5/mapbox"
 MAPBOX_DIRECTIONS_ACCESS_TOKEN:
 COMBIGO_API_BASE_URL: "https://maps.combigo.com/v1.1"
 COMBIGO_API_KEY:
+
+
+######################
+## Debug "mode"
+DEBUG: False

--- a/idunn/utils/es_wrapper.py
+++ b/idunn/utils/es_wrapper.py
@@ -1,12 +1,15 @@
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, RequestsHttpConnection
 from idunn import settings
 
 ES_CONNECTION = None
 
-
 def get_elasticsearch():
     global ES_CONNECTION
+    debug_params = {}
 
     if ES_CONNECTION is None:
-        ES_CONNECTION = Elasticsearch(settings["MIMIR_ES"])
+        if settings["DEBUG"]:
+            debug_params["verify_certs"] = False
+            debug_params["connection_class"] = RequestsHttpConnection
+        ES_CONNECTION = Elasticsearch(settings["MIMIR_ES"], **debug_params)
     return ES_CONNECTION


### PR DESCRIPTION
Sometimes it could be useful to test a local idunn directly towards a specific MIMIR_ES environment.
To handle this possibility this PR simply add a DEBUG parameter as a setting.
Basically it just bypasses the ssl verification at the creation of the ES connection.