### PR TITLE
Fix logging initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from idunn import settings
-from idunn.utils.logging import init_logging, handle_errors
 from idunn.api.urls import get_api_urls
 from idunn.utils.encoders import override_datetime_encoder
+from idunn.utils.prometheus import handle_errors
 from fastapi import FastAPI, APIRouter
 from fastapi.exceptions import RequestValidationError
 from starlette.requests import Request
@@ -9,7 +9,6 @@ from starlette.responses import PlainTextResponse
 import uvicorn
 
 
-init_logging(settings)
 app = FastAPI(title="Idunn", debug=__name__ == '__main__')
 
 v1_routes = get_api_urls(settings)

--- a/idunn/directions/client.py
+++ b/idunn/directions/client.py
@@ -177,6 +177,16 @@ class DirectionsClient:
             )
 
         method_name = method.__name__
+        logger.info(
+            f"Calling directions API '{method_name}'",
+            extra={
+                "method": method_name,
+                "mode": mode,
+                "lang": lang,
+                "from": from_loc,
+                "to": to_loc,
+            },
+        )
         return method(from_loc, to_loc, mode, lang, **kwargs)
 
 

--- a/idunn/utils/logging.py
+++ b/idunn/utils/logging.py
@@ -2,13 +2,8 @@ import json
 import logging
 from logging.config import dictConfig
 
-from starlette.requests import Request
-from starlette.responses import PlainTextResponse
-from .settings import Settings
-from idunn.utils import prometheus
 
-
-def get_logging_dict(settings: Settings):
+def get_logging_dict(settings):
     return {
         "version": 1,
         "disable_existing_loggers": True,
@@ -35,7 +30,7 @@ def get_logging_dict(settings: Settings):
     }
 
 
-def init_logging(settings: Settings):
+def init_logging(settings):
     """
     init the logging for the server
     """
@@ -48,11 +43,3 @@ def init_logging(settings: Settings):
 
         logger = logging.getLogger(module)
         logger.setLevel(log_level)
-
-
-async def handle_errors(request: Request, exception):
-    """
-    overrides the default error handler defined in ServerErrorMiddleware
-    """
-    prometheus.exception("unhandled_error")
-    return PlainTextResponse("Internal Server Error", status_code=500)

--- a/idunn/utils/prometheus.py
+++ b/idunn/utils/prometheus.py
@@ -13,6 +13,7 @@ from prometheus_client import (
 )
 
 from fastapi.routing import APIRoute
+from starlette.responses import PlainTextResponse
 
 
 """ The logic of the Prometheus metrics is defined in this module """
@@ -92,3 +93,11 @@ class MonitoredAPIRoute(APIRoute):
             return response
 
         return custom_handler
+
+
+async def handle_errors(request: Request, exc):
+    """
+    overrides the default error handler defined in ServerErrorMiddleware
+    """
+    exception("unhandled_error")
+    return PlainTextResponse("Internal Server Error", status_code=500)

--- a/idunn/utils/settings.py
+++ b/idunn/utils/settings.py
@@ -3,6 +3,7 @@ import yaml
 from typing import Any
 from inspect import Parameter
 import logging
+from idunn.utils.logging import init_logging
 
 
 def _load_yaml_file(file):
@@ -89,3 +90,4 @@ class SettingsComponent:
 
 
 settings = SettingsComponent("IDUNN")
+init_logging(settings)


### PR DESCRIPTION
* Call `init_logging` on first `settings` import  
If `init_logging` is called after other imports (which initialize their own `logger`) the logging configuration would be ignored.

* Add log message about directions calls (was removed in #101)
