### PR TITLE
Optimize queries to fetch by id in Elasticsearch

### DIFF
--- a/idunn/api/pages_jaunes.py
+++ b/idunn/api/pages_jaunes.py
@@ -57,7 +57,9 @@ class PjSource:
         internal_id = id.replace(f"{self.PLACE_ID_NAMESPACE}:", "", 1)
 
         es_places = self.es.search(
-            index=self.es_index, body={"filter": {"term": {"_id": internal_id}}}
+            index=self.es_index,
+            body={"query": {"bool": {"filter": {"term": {"_id": internal_id}}}}},
+            ignore_unavailable=True,
         )
 
         es_place = es_places.get("hits", {}).get("hits", [])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,12 +88,12 @@ def test_block_null():
     assert resp["blocks"][0]["url"] == "tel:+33142720937"
 
 
-def test_unknow_poi():
+def test_unknown_poi():
     client = TestClient(app)
     response = client.get(url="http://localhost/v1/pois/an_unknown_poi_id",)
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "poi 'an_unknown_poi_id' not found"}
+    assert "'an_unknown_poi_id' not found" in response.json()["detail"]
 
 
 def test_services_and_information():


### PR DESCRIPTION
`filter` queries are executed as post filters by Elasticsearch (and are actually renamed to `post_filter` in recent versions). 
They are significantly slower than bool query (with "filter" nested in a `query` object).
The ES query duration drops from ~50ms to ~1 or 2ms !

See https://stackoverflow.com/a/29131858/5634396 for more details