### PR TITLE
Define settings to enable /docs endpoint with custom path prefix

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,12 +11,10 @@ import uvicorn
 
 # Setup docs settings
 docs_settings = {
-    "docs_url": None,
-    "redoc_url": "/docs",
     "openapi_prefix": settings["DOCS_URL_PREFIX"],
 }
 if not settings["DOCS_ENABLED"]:
-    docs_settings.update({"openapi_url": None, "redoc_url": None})
+    docs_settings.update({"openapi_url": None, "redoc_url": None, "docs_url": None})
 
 
 # Setup FastAPI app

--- a/app.py
+++ b/app.py
@@ -9,29 +9,38 @@ from starlette.responses import PlainTextResponse
 import uvicorn
 
 
-app = FastAPI(title="Idunn", debug=__name__ == '__main__')
+# Setup docs settings
+docs_settings = {
+    "docs_url": None,
+    "redoc_url": "/docs",
+    "openapi_prefix": settings["DOCS_URL_PREFIX"],
+}
+if not settings["DOCS_ENABLED"]:
+    docs_settings.update({"openapi_url": None, "redoc_url": None})
 
+
+# Setup FastAPI app
+app = FastAPI(title="Idunn", version="0.2", debug=__name__ == "__main__", **docs_settings)
 v1_routes = get_api_urls(settings)
-app.include_router(
-    APIRouter(v1_routes),
-    prefix='/v1'
-)
+app.include_router(APIRouter(v1_routes), prefix="/v1")
+
 
 @app.middleware("http")
 async def db_session_middleware(request: Request, call_next):
     response = await call_next(request)
     # TODO: only set it when there is an Origin header!
-    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers["Access-Control-Allow-Origin"] = "*"
     return response
 
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request, exc):
-    return PlainTextResponse(f'Invalid parameter received: {str(exc)}', status_code=404)
+    return PlainTextResponse(f"Invalid parameter received: {str(exc)}", status_code=404)
 
 
+# Override FastAPI defaults
 app.add_exception_handler(Exception, handle_errors)
 override_datetime_encoder()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     uvicorn.run(app, host="127.0.0.1", port=5000, log_level="debug")

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -28,14 +28,14 @@ def get_api_urls(settings):
     """
     metric_handler = get_metric_handler(settings)
     return [
-        APIRoute("/metrics", metric_handler),
-        APIRoute("/status", get_status),
+        APIRoute("/metrics", metric_handler, include_in_schema=False),
+        APIRoute("/status", get_status, include_in_schema=False),
         # Deprecated POI route
         APIRoute("/pois/{id}", get_poi, deprecated=True),
         # Places
         APIRoute("/places", get_places_bbox),
         APIRoute("/places/latlon:{lat}:{lon}", get_place_latlon),
-        APIRoute("/places/{id}", handle_option, methods=["OPTIONS"]),
+        APIRoute("/places/{id}", handle_option, methods=["OPTIONS"], include_in_schema=False),
         APIRoute("/places/{id}", get_place),
         # Categories
         APIRoute("/categories", get_all_categories),

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -22,9 +22,6 @@ def get_metric_handler(settings):
     return expose_metrics
 
 
-from fastapi import HTTPException
-
-
 def get_api_urls(settings):
     """Defines all endpoints
     and handlers to build response

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -111,5 +111,9 @@ PUBLIC_TRANSPORTS_RESTRICT_TO_CITIES: "paris,lyon" # use an empty string to allo
 
 #######################
 ## Geocoding
-
 BRAGI_BASE_URL: "http://bragi:4000"
+
+#######################
+## OpenAPI DOCS
+DOCS_ENABLED: False
+DOCS_URL_PREFIX: "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 100
 target-version = ['py36']
-include = 'idunn/.*\.py$|tests/.*\.py$'
+include = 'idunn/.*\.py$|tests/.*\.py$|app.py'


### PR DESCRIPTION
Define 2 new settings values:
 * `DOCS_ENABLED`: to enable `/docs` endpoint provided by FastAPI (disabled by default)
 * `DOCS_URL_PREFIX`: the base path used to access the OpenAPI schema 
(required when Idunn is deployed behind a reversed proxy with a path different from `/`) 

![image](https://user-images.githubusercontent.com/4726554/74942027-57e56b00-53f4-11ea-87fd-858f5e90eec7.png)


