### PR TITLE
nlu_client: rename tokenizer -> tagger

### DIFF
--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -124,15 +124,15 @@ class NLU_Helper:
         return None
 
     async def get_intentions(self, text, lang):
-        tokenizer_url = settings["NLU_TOKENIZER_URL"]
+        tagger_url = settings["NLU_TAGGER_URL"]
         # this settings is an immutable string required as a parameter for the NLU API
         params = {"text": text, "lang": lang or settings["DEFAULT_LANGUAGE"], "domain": "poi"}
 
         try:
-            response_nlu = await self.client.post(tokenizer_url, json=params)
+            response_nlu = await self.client.post(tagger_url, json=params)
             response_nlu.raise_for_status()
         except Exception:
-            logger.error("Request to NLU tokenizer failed", exc_info=True)
+            logger.error("Request to NLU tagger failed", exc_info=True)
             return []
 
         intentions = []

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -113,7 +113,7 @@ PUBLIC_TRANSPORTS_RESTRICT_TO_CITIES: "paris,lyon" # use an empty string to allo
 ## Geocoding
 BRAGI_BASE_URL: "http://bragi:4000"
 AUTOCOMPLETE_NLU_DEFAULT: False
-NLU_TOKENIZER_URL:
+NLU_TAGGER_URL:
 NLU_CLASSIFIER_URL:
 
 #######################

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -21,7 +21,7 @@ def read_fixture(sPath):
 
 FIXTURE_AUTOCOMPLETE = read_fixture("fixtures/autocomplete/pavillon_paris.json")
 FIXTURE_AUTOCOMPLETE_PARIS = read_fixture("fixtures/autocomplete/paris.json")
-FIXTURE_TOKENIZER = read_fixture("fixtures/autocomplete/nlu.json")
+FIXTURE_TAGGER = read_fixture("fixtures/autocomplete/nlu.json")
 FIXTURE_CLASSIF_pharmacy = read_fixture("fixtures/autocomplete/classif_pharmacy.json")
 
 
@@ -33,8 +33,8 @@ def httpx_mock():
 
 @pytest.fixture
 def mock_NLU(httpx_mock):
-    with override_settings({"NLU_TOKENIZER_URL": NLU_URL, "NLU_CLASSIFIER_URL": CLASSIF_URL}):
-        httpx_mock.post(NLU_URL, content=FIXTURE_TOKENIZER)
+    with override_settings({"NLU_TAGGER_URL": NLU_URL, "NLU_CLASSIFIER_URL": CLASSIF_URL}):
+        httpx_mock.post(NLU_URL, content=FIXTURE_TAGGER)
         httpx_mock.post(CLASSIF_URL, content=FIXTURE_CLASSIF_pharmacy)
         yield
 


### PR DESCRIPTION
It appears that "tagger" is a more appropriate name to describe the nature of this endpoint.