### PR TITLE
Fix: images block fails when POI has no name

### DIFF
--- a/idunn/blocks/images.py
+++ b/idunn/blocks/images.py
@@ -4,7 +4,7 @@ import hashlib
 import posixpath
 import urllib.parse
 from urllib.parse import urlsplit, unquote
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from typing import ClassVar, List
 
 from idunn import settings
@@ -67,6 +67,12 @@ class Image(BaseModel):
     alt: str
     credits: str = ""
     source_url: str
+
+    @validator("alt", pre=True)
+    def validate_alt(cls, v):
+        if not v:
+            return ""
+        return v
 
 
 class ImagesBlock(BaseBlock):

--- a/tests/test_wiki_images.py
+++ b/tests/test_wiki_images.py
@@ -2,35 +2,9 @@ import os
 import json
 import pytest
 from app import app
+from unittest import mock
+from idunn.places import POI
 from starlette.testclient import TestClient
-
-INDICES = {
-    "admin": "munin_admin",
-    "street": "munin_street",
-    "addr": "munin_addr",
-    "poi": "munin_poi",
-}
-
-
-def load_place(file_name, mimir_client, doc_type):
-    index_name = INDICES.get(doc_type)
-
-    filepath = os.path.join(os.path.dirname(__file__), "fixtures", file_name)
-    with open(filepath, "r") as f:
-        place = json.load(f)
-        place_id = place["id"]
-        mimir_client.index(
-            index=index_name,
-            body=place,
-            doc_type=doc_type,  # 'admin', 'street', 'addr' or 'poi'
-            id=place_id,
-            refresh=True,
-        )
-
-
-@pytest.fixture(autouse=True)
-def load_all(mimir_client, init_indices):
-    load_place("orsay_museum.json", mimir_client, "poi")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -54,7 +28,6 @@ def test_orsay_images():
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
-
     resp = response.json()
 
     assert resp["blocks"][4]["type"] == "images"
@@ -62,6 +35,26 @@ def test_orsay_images():
         {
             "url": "https://s2.qwant.com/thumbr/0x0/3/9/43f34b2898978cd1c6cbfa90766ef432d761f02d31f32120eff6db12f616b5/1024px-Logo_musée_d'Orsay.png?u=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Ffr%2Fthumb%2F7%2F73%2FLogo_mus%25C3%25A9e_d%2527Orsay.png%2F1024px-Logo_mus%25C3%25A9e_d%2527Orsay.png&q=0&b=1&p=0&a=0",
             "alt": "Musée d'Orsay",
+            "credits": "",
+            "source_url": "https://upload.wikimedia.org/wikipedia/fr/thumb/7/73/Logo_mus%C3%A9e_d%27Orsay.png/1024px-Logo_mus%C3%A9e_d%27Orsay.png",
+        },
+    ]
+
+
+@mock.patch.object(POI, "get_name", lambda *x: None)
+def test_image_for_unnamed_poi():
+    client = TestClient(app)
+    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr",)
+
+    assert response.status_code == 200
+    assert response.headers.get("Access-Control-Allow-Origin") == "*"
+    resp = response.json()
+
+    assert resp["blocks"][4]["type"] == "images"
+    assert resp["blocks"][4]["images"] == [
+        {
+            "url": "https://s2.qwant.com/thumbr/0x0/3/9/43f34b2898978cd1c6cbfa90766ef432d761f02d31f32120eff6db12f616b5/1024px-Logo_musée_d'Orsay.png?u=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Ffr%2Fthumb%2F7%2F73%2FLogo_mus%25C3%25A9e_d%2527Orsay.png%2F1024px-Logo_mus%25C3%25A9e_d%2527Orsay.png&q=0&b=1&p=0&a=0",
+            "alt": "",
             "credits": "",
             "source_url": "https://upload.wikimedia.org/wikipedia/fr/thumb/7/73/Logo_mus%C3%A9e_d%27Orsay.png/1024px-Logo_mus%C3%A9e_d%27Orsay.png",
         },


### PR DESCRIPTION
The `alt: str` property for images is derived from the poi name.
But the case when no name is available was not handled.