### PR TITLE
Place model: add 'country_code' in address object

### DIFF
--- a/idunn/blocks/covid19.py
+++ b/idunn/blocks/covid19.py
@@ -40,7 +40,7 @@ class Covid19Block(BaseBlock):
 
         properties = es_poi.properties
         # Check if this is a french admin, otherwise we return nothing.
-        if "FR" not in es_poi.get_country_codes():
+        if es_poi.get_country_code() != "FR":
             return None
 
         opening_hours = properties.get("opening_hours:covid19")

--- a/idunn/places/event.py
+++ b/idunn/places/event.py
@@ -32,7 +32,6 @@ class Event(BasePlace):
         return {
             "name": self.get("placename"),
             "label": self.get("address"),
-            "city": self.get("city"),
             "admin": self.build_admin(lang),
             "admins": self.build_admins(),
         }

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -166,6 +166,7 @@ class PjPOI(BasePlace):
                 "label": f"{street} ({city})",
                 "postcodes": [postal_code] if postal_code else [],
             },
+            "country_code": self.get_country_code(),
         }
 
     def get_country_codes(self):

--- a/idunn/places/place.py
+++ b/idunn/places/place.py
@@ -8,6 +8,37 @@ class PlaceMeta(BaseModel):
     source: Optional[str]
 
 
+class Street(BaseModel):
+    id: Optional[str]
+    name: Optional[str]
+    label: Optional[str]
+    postcodes: Optional[List[str]]
+
+
+class AdministrativeRegion(BaseModel):
+    id: Optional[str]
+    name: Optional[str]
+    label: Optional[str]
+    class_name: Optional[str]
+    postcodes: Optional[List[str]]
+
+
+class AdministrativeRegionContext(BaseModel):
+    label: Optional[str]
+
+
+class Address(BaseModel):
+    id: Optional[str]
+    name: Optional[str]
+    label: Optional[str]
+    housenumber: Optional[str]
+    street: Optional[Street]
+    postcode: Optional[str]
+    admins: Optional[List[AdministrativeRegion]]
+    admin: Optional[AdministrativeRegionContext]
+    country_code: Optional[str]
+
+
 class Place(BaseModel):
     type: str
     id: Optional[str]
@@ -16,6 +47,6 @@ class Place(BaseModel):
     class_name: Optional[str]
     subclass_name: Optional[str]
     geometry: Optional[dict]
-    address: Optional[dict]
+    address: Optional[Address]
     blocks: List[BaseBlock] = BlocksValidator(allowed_blocks=BLOCKS_BY_VERBOSITY.get(LONG))
     meta: PlaceMeta

--- a/tests/fixtures/address_du_moulin.json
+++ b/tests/fixtures/address_du_moulin.json
@@ -70,7 +70,8 @@
 				"name": "France",
 				"weight": 0.015618298409952111,
 				"zip_codes": [],
-				"zone_type": "country"
+				"zone_type": "country",
+				"country_codes": ["FR"]
 			},
 			{
 				"admin_type": "City",

--- a/tests/fixtures/admin_goujounac.json
+++ b/tests/fixtures/admin_goujounac.json
@@ -2289,5 +2289,203 @@
     44.5978805
   ],
   "admin_type": "City",
-  "zone_type": "city"
+  "zone_type": "city",
+  "administrative_regions": [
+    {
+      "id": "admin:osm:relation:7454",
+      "insee": "46",
+      "level": 6,
+      "label": "Lot, Occitanie, France",
+      "name": "Lot",
+      "zip_codes": [],
+      "weight": 0.0,
+      "approx_coord": {
+        "coordinates": [
+          1.4364998999999998,
+          44.4495
+        ],
+        "type": "Point"
+      },
+      "coord": {
+        "lon": 1.4364998999999998,
+        "lat": 44.4495
+      },
+      "administrative_regions": [],
+      "bbox": [
+        0.9812326,
+        44.2033516,
+        2.2112892,
+        45.0466382
+      ],
+      "zone_type": "state_district",
+      "parent_id": "admin:osm:relation:3792883",
+      "country_codes": [],
+      "codes": [
+        {
+          "name": "ISO3166-2",
+          "value": "FR-46"
+        },
+        {
+          "name": "ref:INSEE",
+          "value": "46"
+        },
+        {
+          "name": "ref:NUTS",
+          "value": "FR625"
+        },
+        {
+          "name": "wikidata",
+          "value": "Q12576"
+        }
+      ],
+      "names": {
+        "br": "Lot",
+        "ca": "Òlt",
+        "fr": "Lot"
+      },
+      "labels": {
+        "br": "Lot, Okitania, Bro-C'hall",
+        "ca": "Òlt, Occitània, França",
+        "de": "Lot, Okzitanien, Frankreich",
+        "en": "Lot, Occitania, France",
+        "es": "Lot, Occitania, Francia",
+        "it": "Lot, Occitania, Francia"
+      }
+    },
+    {
+      "id": "admin:osm:relation:3792883",
+      "insee": "76",
+      "level": 4,
+      "label": "Occitanie, France",
+      "name": "Occitanie",
+      "zip_codes": [],
+      "weight": 0.00031557285714285715,
+      "approx_coord": {
+        "coordinates": [
+          1.4442469,
+          43.6044622
+        ],
+        "type": "Point"
+      },
+      "coord": {
+        "lon": 1.4442469,
+        "lat": 43.6044622
+      },
+      "administrative_regions": [],
+      "bbox": [
+        -0.3272334,
+        42.3327551,
+        4.8455335,
+        45.0466382
+      ],
+      "zone_type": "state",
+      "parent_id": "admin:osm:relation:2202162",
+      "country_codes": [],
+      "codes": [
+        {
+          "name": "ISO3166-2",
+          "value": "FR-OCC"
+        },
+        {
+          "name": "ref:INSEE",
+          "value": "76"
+        },
+        {
+          "name": "ref:NUTS",
+          "value": "FR62"
+        },
+        {
+          "name": "wikidata",
+          "value": "Q18678265"
+        }
+      ],
+      "names": {
+        "br": "Okitania",
+        "ca": "Occitània",
+        "de": "Okzitanien",
+        "en": "Occitania",
+        "es": "Occitania",
+        "fr": "Occitanie",
+        "it": "Occitania"
+      },
+      "labels": {
+        "br": "Okitania, Bro-C'hall",
+        "ca": "Occitània, França",
+        "de": "Okzitanien, Frankreich",
+        "en": "Occitania, France",
+        "es": "Occitania, Francia",
+        "it": "Occitania, Francia"
+      }
+    },
+    {
+      "id": "admin:osm:relation:2202162",
+      "insee": "",
+      "level": 2,
+      "label": "France",
+      "name": "France",
+      "zip_codes": [],
+      "weight": 0.0015625185714285715,
+      "approx_coord": {
+        "coordinates": [
+          2.3514616,
+          48.8566969
+        ],
+        "type": "Point"
+      },
+      "coord": {
+        "lon": 2.3514616,
+        "lat": 48.8566969
+      },
+      "administrative_regions": [],
+      "bbox": [
+        -178.3873749,
+        -50.2187169,
+        172.30571519999998,
+        51.3055721
+      ],
+      "zone_type": "country",
+      "parent_id": null,
+      "country_codes": [
+        "FR"
+      ],
+      "codes": [
+        {
+          "name": "ISO3166-1",
+          "value": "FR"
+        },
+        {
+          "name": "ISO3166-1:alpha2",
+          "value": "FR"
+        },
+        {
+          "name": "ISO3166-1:alpha3",
+          "value": "FRA"
+        },
+        {
+          "name": "ISO3166-1:numeric",
+          "value": "250"
+        },
+        {
+          "name": "wikidata",
+          "value": "Q142"
+        }
+      ],
+      "names": {
+        "br": "Bro-C'hall",
+        "ca": "França",
+        "de": "Frankreich",
+        "en": "France",
+        "es": "Francia",
+        "fr": "France",
+        "it": "Francia"
+      },
+      "labels": {
+        "br": "Bro-C'hall",
+        "ca": "França",
+        "de": "Frankreich",
+        "es": "Francia",
+        "it": "Francia"
+      }
+    }
+  ]
 }

--- a/tests/fixtures/blancs_manteaux.json
+++ b/tests/fixtures/blancs_manteaux.json
@@ -164,7 +164,8 @@
       ],
       "zone_type": "country",
       "parent_id": null,
-      "codes": []
+      "codes": [],
+      "country_codes": ["FR"]
     }
   ],
   "weight": 0.6666666666666666,

--- a/tests/fixtures/cinema_multiplexe.json
+++ b/tests/fixtures/cinema_multiplexe.json
@@ -71,7 +71,8 @@
       ],
       "zone_type": "country",
       "parent_id": null,
-      "codes": []
+      "codes": [],
+      "country_codes": ["FR"]
     },
     {
       "id": "admin:osm:relation:1076124",

--- a/tests/fixtures/louvre_museum.json
+++ b/tests/fixtures/louvre_museum.json
@@ -143,7 +143,8 @@
                     "parent_id": null,
                     "weight": 0.015618298409952111,
                     "zip_codes": [],
-                    "zone_type": "country"
+                    "zone_type": "country",
+                    "country_codes": ["FR"]
                 },
                 {
                     "bbox": [

--- a/tests/fixtures/orsay_museum.json
+++ b/tests/fixtures/orsay_museum.json
@@ -164,7 +164,8 @@
       ],
       "zone_type": "country",
       "parent_id": null,
-      "codes": []
+      "codes": [],
+      "country_codes": ["FR"]
     }
   ],
   "weight": 1.0,
@@ -475,7 +476,8 @@
           ],
           "zone_type": "country",
           "parent_id": null,
-          "codes": []
+          "codes": [],
+          "country_codes": ["FR"]
         }
       ],
       "label": "Rue de la Légion d'Honneur (Paris)",

--- a/tests/fixtures/patisserie_peron.json
+++ b/tests/fixtures/patisserie_peron.json
@@ -71,7 +71,8 @@
       ],
       "zone_type": "country",
       "parent_id": null,
-      "codes": []
+      "codes": [],
+      "country_codes": ["FR"]
     },
     {
       "id": "admin:osm:relation:1076124",

--- a/tests/fixtures/street_birnenweg.json
+++ b/tests/fixtures/street_birnenweg.json
@@ -61,7 +61,8 @@
 			"name": "Deutschland",
 			"weight": 0.024579080066797,
 			"zip_codes": [],
-			"zone_type": "country"
+			"zone_type": "country",
+			"country_codes": ["DE"]
 		},
 		{
 			"admin_type": "Unknown",

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -70,6 +70,7 @@ def test_bbox():
                         ANY,
                         ANY,
                     ],
+                    "country_code": "FR",
                 },
                 "blocks": [
                     {
@@ -334,6 +335,7 @@ def test_bbox():
                         "postcodes": ["75007", "75008"],
                     },
                     "admins": ANY,
+                    "country_code": "FR",
                 },
                 "blocks": [
                     {
@@ -607,6 +609,7 @@ def test_single_raw_filter():
                             "postcodes": [],
                         },
                     ],
+                    "country_code": "FR",
                 },
                 "blocks": [
                     {

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -43,6 +43,7 @@ def test_full():
                 "label": "Rue de Lille (Paris)",
                 "postcodes": ["75007", "75008"],
             },
+            "country_code": "FR",
         },
         "blocks": [
             {

--- a/tests/test_kuzzle.py
+++ b/tests/test_kuzzle.py
@@ -43,7 +43,6 @@ def test_kuzzle_event_ok():
         assert firstEventData["subclass_name"] == "event"
         assert firstEventData["address"]["name"] == "Cité des Sciences et de l'Industrie"
         assert firstEventData["address"]["label"] == "30 Avenue Corentin Cariou, Paris"
-        assert firstEventData["address"]["city"] == "Paris"
         assert firstEventData["blocks"][0]["type"] == "event_opening_dates"
         assert firstEventData["blocks"][1]["type"] == "event_description"
         assert firstEventData["blocks"][2]["type"] == "website"

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -1,4 +1,5 @@
 import urllib
+from unittest.mock import ANY
 from app import app
 from starlette.testclient import TestClient
 from freezegun import freeze_time
@@ -39,13 +40,14 @@ def test_full_query_admin():
         },
         "address": {
             "admin": {"label": "Goujounac (46250), Lot, Occitanie, France",},
-            "admins": [],
+            "admins": [ANY, ANY, ANY],
             "id": None,
             "label": None,
             "name": None,
             "housenumber": None,
             "postcode": "46250",
             "street": {"id": None, "name": None, "label": None, "postcodes": None},
+            "country_code": "FR",
         },
         "blocks": [],
         "meta": {"source": None},
@@ -119,6 +121,7 @@ def test_full_query_street():
                     "postcodes": [],
                 },
             ],
+            "country_code": "DE",
         },
         "blocks": [],
         "meta": {"source": None},
@@ -194,6 +197,7 @@ def test_full_query_address():
                     "postcodes": ["55000"],
                 },
             ],
+            "country_code": "FR",
         },
         "blocks": [],
         "meta": {"source": None},
@@ -304,6 +308,7 @@ def test_full_query_poi():
                 "postcodes": [],
             },
         ],
+        "country_code": "FR",
     }
     assert resp["blocks"] == [
         {


### PR DESCRIPTION
* Define `Address` model, used in existing `Place` response model
* Implement `.get_country_code()` for all places  
This method returns the least specific country code among all codes defined in administrative regions.
* Add `country_code` field in address objects