### PR TITLE
Consolidate POI status related to covid-19, improve error handling

### DIFF
--- a/idunn/blocks/covid19.py
+++ b/idunn/blocks/covid19.py
@@ -1,19 +1,28 @@
 import logging
+from enum import Enum
+from typing import ClassVar, Optional
+
 from idunn import settings
 from idunn.utils.covid19_dataset import get_poi_covid_status
 from .base import BaseBlock
 from .opening_hour import OpeningHourBlock, parse_time_block
-from pydantic import constr
-from typing import ClassVar, Optional
+
 
 logger = logging.getLogger(__name__)
 
 
+class CovidOpeningStatus(str, Enum):
+    open_as_usual = "open_as_usual"
+    open = "open"
+    maybe_open = "maybe_open"
+    closed = "closed"
+    unknown = "unknown"
+
+
 class Covid19Block(BaseBlock):
     BLOCK_TYPE: ClassVar = "covid19"
-    STATUSES: ClassVar = ["open_as_usual", "open", "maybe_open", "closed", "unknown"]
 
-    status: constr(regex="^({})$".format("|".join(STATUSES)))
+    status: CovidOpeningStatus
     opening_hours: Optional[OpeningHourBlock]
     note: Optional[str]
     contribute_url: Optional[str]
@@ -43,51 +52,57 @@ class Covid19Block(BaseBlock):
         if es_poi.get_country_code() != "FR":
             return None
 
-        opening_hours = properties.get("opening_hours:covid19")
+        opening_hours = None
         note = es_poi.properties.get("description:covid19")
-        status = "unknown"
-
+        status = CovidOpeningStatus.unknown
         contribute_url = None
-        covid_status = None
-        if es_poi.get_meta().source == "osm" and settings["COVID19_USE_REDIS_DATASET"]:
-            covid_status = get_poi_covid_status(es_poi.get_id())
-            if covid_status is not None:
-                contribute_url = cls.get_ca_reste_ouvert_url(es_poi)
 
-        if opening_hours == "same":
+        raw_opening_hours = properties.get("opening_hours:covid19")
+        covid_status_from_redis = None
+
+        if es_poi.get_meta().source == "osm" and settings["COVID19_USE_REDIS_DATASET"]:
+            covid_status_from_redis = get_poi_covid_status(es_poi.get_id())
+
+        if covid_status_from_redis is not None:
+            contribute_url = cls.get_ca_reste_ouvert_url(es_poi)
+            note = covid_status_from_redis.infos or None
+
+            if covid_status_from_redis.opening_hours:
+                opening_hours = parse_time_block(
+                    OpeningHourBlock, es_poi, lang, covid_status_from_redis.opening_hours
+                )
+
+            if covid_status_from_redis.status == "ouvert":
+                status = CovidOpeningStatus.open_as_usual
+            elif covid_status_from_redis.status == "ouvert_adapté":
+                status = CovidOpeningStatus.open
+            elif covid_status_from_redis.status == "partiel":
+                status = CovidOpeningStatus.maybe_open
+            elif covid_status_from_redis.status == "fermé":
+                status = CovidOpeningStatus.closed
+
+        elif raw_opening_hours == "same":
             opening_hours = parse_time_block(
                 OpeningHourBlock, es_poi, lang, properties.get("opening_hours")
             )
-            status = "open_as_usual"
-        elif opening_hours == "off":
-            opening_hours = None
-            status = "closed"
-        elif opening_hours is not None:
+            status = CovidOpeningStatus.open_as_usual
+        elif raw_opening_hours == "open":
+            status = CovidOpeningStatus.open
+        elif raw_opening_hours == "restricted":
+            status = CovidOpeningStatus.maybe_open
+        elif raw_opening_hours == "off":
+            status = CovidOpeningStatus.closed
+        elif raw_opening_hours is not None:
             opening_hours = parse_time_block(OpeningHourBlock, es_poi, lang, opening_hours)
             if opening_hours is None:
                 status = "unknown"
             elif opening_hours.status in ["open", "closed"]:
-                if properties.get("opening_hours:covid19") == properties.get("opening_hours"):
-                    status = "open_as_usual"
+                if raw_opening_hours == properties.get("opening_hours"):
+                    status = CovidOpeningStatus.open_as_usual
                 else:
-                    status = "open"
+                    status = CovidOpeningStatus.open
             else:
-                status = "maybe_open"
-        elif covid_status is not None:
-            if covid_status.opening_hours:
-                opening_hours = parse_time_block(
-                    OpeningHourBlock, es_poi, lang, covid_status.opening_hours
-                )
-            if covid_status.status == "ouvert":
-                status = "open_as_usual"
-            elif covid_status.status == "ouvert_adapté":
-                status = "open"
-            elif covid_status.status == "partiel":
-                status = "maybe_open"
-            elif covid_status.status == "fermé":
-                status = "closed"
-            if not note:
-                note = covid_status.infos or None
+                status = CovidOpeningStatus.maybe_open
 
         return cls(
             status=status, note=note, opening_hours=opening_hours, contribute_url=contribute_url

--- a/idunn/blocks/covid19.py
+++ b/idunn/blocks/covid19.py
@@ -9,6 +9,7 @@ from .opening_hour import OpeningHourBlock, parse_time_block
 
 
 logger = logging.getLogger(__name__)
+COVID19_BLOCK_COUNTRIES = settings["COVID19_BLOCK_COUNTRIES"].split(",")
 
 
 class CovidOpeningStatus(str, Enum):
@@ -49,7 +50,7 @@ class Covid19Block(BaseBlock):
 
         properties = es_poi.properties
         # Check if this is a french admin, otherwise we return nothing.
-        if es_poi.get_country_code() != "FR":
+        if es_poi.get_country_code() not in COVID19_BLOCK_COUNTRIES:
             return None
 
         opening_hours = None

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -95,7 +95,7 @@ class BasePlace(dict):
             key=lambda a: ZONE_TYPE_ORDER_KEY.get(a.get("zone_type"), 0),
             reverse=True,
         )
-        return [c for admin in ordered_admins for c in admin.get("country_codes", [])]
+        return [c.upper() for admin in ordered_admins for c in admin.get("country_codes", [])]
 
     def get_country_code(self):
         return next(iter(self.get_country_codes()), None)

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -127,3 +127,4 @@ COVID19_USE_REDIS_DATASET: True
 COVID19_OSM_DATASET_URL: https://www.data.gouv.fr/fr/datasets/r/3ed2f2eb-11a0-4497-a445-1f6f96f3e4aa
 COVID19_OSM_DATASET_EXPIRE: 7200 # seconds
 COVID19_POI_EXPIRE: 86400 # seconds
+COVID19_BLOCK_COUNTRIES: "FR" # comma separated list

--- a/idunn/utils/redis.py
+++ b/idunn/utils/redis.py
@@ -46,8 +46,7 @@ class RedisWrapper:
             prometheus.exception("RedisError")
             if raise_on_error:
                 raise
-            else:
-                logging.exception("Got a RedisError")
+            logging.exception("Got a RedisError")
 
     @classmethod
     def _get_value(cls, key):

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,6 +12,6 @@ services:
     - "9200"
 
   wiki_redis:
-    image: redis:3.2-alpine
+    image: redis:4-alpine
     ports:
     - "6379"


### PR DESCRIPTION
_These 3 commits may be reviewed separately_

* More explicit messages about Redis errors 
* Clean opening status logic in covid19 block
  * use Redis data in priority (maintained by CaResteOuvert, and refreshed more regularly)
  * handle "open" and "restricted" values for `opening_hours:covid19`
* Define a list of country codes in settings where covid19 block should be enabled



