### PR TITLE
Implement POIs search by bbox and query via Bragi

### DIFF
--- a/idunn/geocoder/bragi_client.py
+++ b/idunn/geocoder/bragi_client.py
@@ -46,5 +46,20 @@ class BragiClient:
             logger.exception("Autocomplete invalid response")
             raise HTTPException(503, "Invalid response from the geocoder")
 
+    async def pois_query_in_bbox(self, query, bbox, limit, lang=None):
+        query_params = {"q": query, "lang": lang, "limit": limit, "type[]": "poi"}
+        xmin, ymin, xmax, ymax = bbox
+        shape = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax], [xmin, ymin]]
+                ],
+            },
+            "properties": {},
+        }
+        return await self.raw_autocomplete(params=query_params, body={"shape": shape})
+
 
 bragi_client = BragiClient()

--- a/idunn/places/__init__.py
+++ b/idunn/places/__init__.py
@@ -1,6 +1,6 @@
 from .address import Address
 from .admin import Admin
-from .poi import POI
+from .poi import POI, BragiPOI
 from .street import Street
 from .place import Place
 from .pj_poi import PjPOI

--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -116,9 +116,11 @@ class BasePlace(dict):
 
         id = raw_address.get("id")
         name = raw_address.get("name")
-        housenumber = raw_address.get("house_number")
         label = raw_address.get("label")
         street = self.build_street()
+
+        # ES raw data uses "house_number" whereas Bragi returns "housenumber"
+        housenumber = raw_address.get("house_number") or raw_address.get("housenumber")
 
         return {
             "id": id,

--- a/idunn/places/poi.py
+++ b/idunn/places/poi.py
@@ -26,3 +26,27 @@ class POI(BasePlace):
 
     def get_meta(self):
         return PlaceMeta(source="osm")
+
+
+class BragiPOI(POI):
+    def __init__(self, bragi_feature):
+        coord = bragi_feature.get("geometry", {}).get("coordinates") or []
+        if len(coord) == 2:
+            lon, lat = coord
+        else:
+            lon, lat = None, None
+        es_dict = dict(bragi_feature["properties"]["geocoding"], coord={"lon": lon, "lat": lat})
+        super().__init__(es_dict)
+
+    def get_raw_street(self):
+        raw_address = self.get_raw_address()
+        return {"name": raw_address.get("street")}
+
+    def get_postcodes(self):
+        postcode = self.get("postcode")
+        if postcode:
+            return [postcode]
+        return None
+
+    def get_country_codes(self):
+        return [c.upper() for c in self.get_raw_address().get("country_codes") or []]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 100
-target-version = ['py36']
+target-version = ['py38']
 include = 'idunn/.*\.py$|tests/.*\.py$|app.py'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import responses
 import re
+import respx
 from elasticsearch import Elasticsearch
 
 from .utils import override_settings
@@ -213,3 +214,9 @@ def load_all(mimir_client, init_indices):
     load_place("street_birnenweg.json", mimir_client, doc_type="street")
     load_place("address_du_moulin.json", mimir_client, doc_type="addr")
     load_place("admin_dunkerque.json", mimir_client, doc_type="admin")
+
+
+@pytest.fixture
+def httpx_mock():
+    with respx.mock(assert_all_called=False) as rsps:
+        yield rsps

--- a/tests/fixtures/autocomplete/carrefour_in_bbox.json
+++ b/tests/fixtures/autocomplete/carrefour_in_bbox.json
@@ -1,0 +1,2031 @@
+{
+  "type": "FeatureCollection",
+  "geocoding": {
+    "version": "0.1.0",
+    "query": ""
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          -4.506251081451865,
+          48.403901325339646
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "geocoding": {
+          "id": "osm:node:4396200689",
+          "type": "poi",
+          "label": "Carrefour Market (Brest)",
+          "name": "Carrefour Market",
+          "postcode": "29200",
+          "city": "Brest",
+          "citycode": "29019",
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:1076124",
+              "insee": "29019",
+              "level": 8,
+              "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+              "name": "Brest",
+              "zip_codes": [
+                "29200"
+              ],
+              "coord": {
+                "lon": -4.4860088,
+                "lat": 48.3905283
+              },
+              "bbox": [
+                -4.5689169,
+                48.3572972,
+                -4.4278311,
+                48.4595521
+              ],
+              "zone_type": "city",
+              "parent_id": "admin:osm:relation:102430",
+              "codes": [
+                {
+                  "name": "ref:FR:SIREN",
+                  "value": "212900195"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29019"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12193"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:102430",
+              "insee": "29",
+              "level": 6,
+              "label": "Finist\u00e8re, Bretagne, France",
+              "name": "Finist\u00e8re",
+              "zip_codes": [],
+              "coord": {
+                "lon": -4.1024782,
+                "lat": 47.9960325
+              },
+              "bbox": [
+                -5.1440329,
+                47.7012815,
+                -3.3866547,
+                48.7538213
+              ],
+              "zone_type": "state_district",
+              "parent_id": "admin:osm:relation:102740",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-29"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR522"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q3389"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:102740",
+              "insee": "53",
+              "level": 4,
+              "label": "Bretagne, France",
+              "name": "Bretagne",
+              "zip_codes": [],
+              "coord": {
+                "lon": -1.6800198,
+                "lat": 48.1113387
+              },
+              "bbox": [
+                -5.1440329,
+                47.2777959,
+                -1.01569,
+                48.9086459
+              ],
+              "zone_type": "state",
+              "parent_id": "admin:osm:relation:2202162",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-BRE"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "53"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR52"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12130"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "bbox": [
+                -5.4517733,
+                41.261115499999995,
+                9.8282225,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ]
+            }
+          ],
+          "poi_types": [
+            {
+              "id": "class_grocery:subclass_supermarket",
+              "name": "class_grocery subclass_supermarket"
+            }
+          ],
+          "properties": [
+            {
+              "key": "name",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "brand:wikipedia",
+              "value": "fr:Carrefour Market"
+            },
+            {
+              "key": "name_int",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "brand:wikidata",
+              "value": "Q2689639"
+            },
+            {
+              "key": "name:fr",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "brand",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "name:latin",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "shop",
+              "value": "supermarket"
+            },
+            {
+              "key": "poi_subclass",
+              "value": "supermarket"
+            },
+            {
+              "key": "poi_class",
+              "value": "grocery"
+            }
+          ],
+          "address": {
+            "id": "street:osm:relation:2253371",
+            "type": "street",
+            "label": "Rue Pierre Tr\u00e9pos (Brest)",
+            "name": "Rue Pierre Tr\u00e9pos",
+            "street": "Rue Pierre Tr\u00e9pos",
+            "postcode": "29200",
+            "city": "Brest",
+            "citycode": "29019",
+            "administrative_regions": [
+              {
+                "id": "admin:osm:relation:1076124",
+                "insee": "29019",
+                "level": 8,
+                "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+                "name": "Brest",
+                "zip_codes": [
+                  "29200"
+                ],
+                "coord": {
+                  "lon": -4.4860088,
+                  "lat": 48.3905283
+                },
+                "bbox": [
+                  -4.5689169,
+                  48.3572972,
+                  -4.4278311,
+                  48.4595521
+                ],
+                "zone_type": "city",
+                "parent_id": "admin:osm:relation:102430",
+                "codes": [
+                  {
+                    "name": "ref:FR:SIREN",
+                    "value": "212900195"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29019"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12193"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:102430",
+                "insee": "29",
+                "level": 6,
+                "label": "Finist\u00e8re, Bretagne, France",
+                "name": "Finist\u00e8re",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -4.1024782,
+                  "lat": 47.9960325
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.7012815,
+                  -3.3866547,
+                  48.7538213
+                ],
+                "zone_type": "state_district",
+                "parent_id": "admin:osm:relation:102740",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-29"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR522"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q3389"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:102740",
+                "insee": "53",
+                "level": 4,
+                "label": "Bretagne, France",
+                "name": "Bretagne",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -1.6800198,
+                  "lat": 48.1113387
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.2777959,
+                  -1.01569,
+                  48.9086459
+                ],
+                "zone_type": "state",
+                "parent_id": "admin:osm:relation:2202162",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-BRE"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "53"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR52"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12130"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:2202162",
+                "insee": "",
+                "level": 2,
+                "label": "France",
+                "name": "France",
+                "zip_codes": [],
+                "coord": {
+                  "lon": 2.3514616,
+                  "lat": 48.8566969
+                },
+                "bbox": [
+                  -5.4517733,
+                  41.261115499999995,
+                  9.8282225,
+                  51.3055721
+                ],
+                "zone_type": "country",
+                "parent_id": null,
+                "codes": [
+                  {
+                    "name": "ISO3166-1",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha2",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha3",
+                    "value": "FRA"
+                  },
+                  {
+                    "name": "ISO3166-1:numeric",
+                    "value": "250"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q142"
+                  }
+                ]
+              }
+            ],
+            "country_codes": [
+              "FR"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          -4.524676181007862,
+          48.38830888996107
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "geocoding": {
+          "id": "osm:node:1550934885",
+          "type": "poi",
+          "label": "Carrefour (Brest)",
+          "name": "Carrefour",
+          "postcode": "29200",
+          "city": "Brest",
+          "citycode": "29019",
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:102430",
+              "insee": "29",
+              "level": 6,
+              "label": "Finist\u00e8re, Bretagne, France",
+              "name": "Finist\u00e8re",
+              "zip_codes": [],
+              "coord": {
+                "lon": -4.1024782,
+                "lat": 47.9960325
+              },
+              "bbox": [
+                -5.1440329,
+                47.7012815,
+                -3.3866547,
+                48.7538213
+              ],
+              "zone_type": "state_district",
+              "parent_id": "admin:osm:relation:102740",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-29"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR522"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q3389"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:102740",
+              "insee": "53",
+              "level": 4,
+              "label": "Bretagne, France",
+              "name": "Bretagne",
+              "zip_codes": [],
+              "coord": {
+                "lon": -1.6800198,
+                "lat": 48.1113387
+              },
+              "bbox": [
+                -5.1440329,
+                47.2777959,
+                -1.01569,
+                48.9086459
+              ],
+              "zone_type": "state",
+              "parent_id": "admin:osm:relation:2202162",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-BRE"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "53"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR52"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12130"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "bbox": [
+                -5.4517733,
+                41.261115499999995,
+                9.8282225,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:1076124",
+              "insee": "29019",
+              "level": 8,
+              "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+              "name": "Brest",
+              "zip_codes": [
+                "29200"
+              ],
+              "coord": {
+                "lon": -4.4860088,
+                "lat": 48.3905283
+              },
+              "bbox": [
+                -4.5689169,
+                48.3572972,
+                -4.4278311,
+                48.4595521
+              ],
+              "zone_type": "city",
+              "parent_id": "admin:osm:relation:102430",
+              "codes": [
+                {
+                  "name": "ref:FR:SIREN",
+                  "value": "212900195"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29019"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12193"
+                }
+              ]
+            }
+          ],
+          "poi_types": [
+            {
+              "id": "class_grocery:subclass_supermarket",
+              "name": "class_grocery subclass_supermarket"
+            }
+          ],
+          "properties": [
+            {
+              "key": "brand:wikipedia",
+              "value": "fr:Carrefour (enseigne)"
+            },
+            {
+              "key": "wheelchair",
+              "value": "yes"
+            },
+            {
+              "key": "brand:wikidata",
+              "value": "Q217599"
+            },
+            {
+              "key": "addr:city",
+              "value": "Brest"
+            },
+            {
+              "key": "operator",
+              "value": "Carrefour"
+            },
+            {
+              "key": "name",
+              "value": "Carrefour"
+            },
+            {
+              "key": "shop",
+              "value": "supermarket"
+            },
+            {
+              "key": "internet_access",
+              "value": "wlan"
+            },
+            {
+              "key": "name_int",
+              "value": "Carrefour"
+            },
+            {
+              "key": "toilets:wheelchair",
+              "value": "yes"
+            },
+            {
+              "key": "brand",
+              "value": "Carrefour"
+            },
+            {
+              "key": "name:latin",
+              "value": "Carrefour"
+            },
+            {
+              "key": "addr:postcode",
+              "value": "29200"
+            },
+            {
+              "key": "brand:website",
+              "value": "http://www.carrefour.fr"
+            },
+            {
+              "key": "poi_subclass",
+              "value": "supermarket"
+            },
+            {
+              "key": "poi_class",
+              "value": "grocery"
+            }
+          ],
+          "address": {
+            "id": "addr:-4.525565;48.3887:120",
+            "type": "house",
+            "label": "120 Boulevard de Plymouth (Brest)",
+            "name": "120 Boulevard de Plymouth",
+            "housenumber": "120",
+            "street": "Boulevard de Plymouth",
+            "postcode": "29200",
+            "city": "Brest",
+            "citycode": "29019",
+            "administrative_regions": [
+              {
+                "id": "admin:osm:relation:102430",
+                "insee": "29",
+                "level": 6,
+                "label": "Finist\u00e8re, Bretagne, France",
+                "name": "Finist\u00e8re",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -4.1024782,
+                  "lat": 47.9960325
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.7012815,
+                  -3.3866547,
+                  48.7538213
+                ],
+                "zone_type": "state_district",
+                "parent_id": "admin:osm:relation:102740",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-29"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR522"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q3389"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:102740",
+                "insee": "53",
+                "level": 4,
+                "label": "Bretagne, France",
+                "name": "Bretagne",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -1.6800198,
+                  "lat": 48.1113387
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.2777959,
+                  -1.01569,
+                  48.9086459
+                ],
+                "zone_type": "state",
+                "parent_id": "admin:osm:relation:2202162",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-BRE"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "53"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR52"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12130"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:2202162",
+                "insee": "",
+                "level": 2,
+                "label": "France",
+                "name": "France",
+                "zip_codes": [],
+                "coord": {
+                  "lon": 2.3514616,
+                  "lat": 48.8566969
+                },
+                "bbox": [
+                  -5.4517733,
+                  41.261115499999995,
+                  9.8282225,
+                  51.3055721
+                ],
+                "zone_type": "country",
+                "parent_id": null,
+                "codes": [
+                  {
+                    "name": "ISO3166-1",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha2",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha3",
+                    "value": "FRA"
+                  },
+                  {
+                    "name": "ISO3166-1:numeric",
+                    "value": "250"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q142"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:1076124",
+                "insee": "29019",
+                "level": 8,
+                "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+                "name": "Brest",
+                "zip_codes": [
+                  "29200"
+                ],
+                "coord": {
+                  "lon": -4.4860088,
+                  "lat": 48.3905283
+                },
+                "bbox": [
+                  -4.5689169,
+                  48.3572972,
+                  -4.4278311,
+                  48.4595521
+                ],
+                "zone_type": "city",
+                "parent_id": "admin:osm:relation:102430",
+                "codes": [
+                  {
+                    "name": "ref:FR:SIREN",
+                    "value": "212900195"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29019"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12193"
+                  }
+                ]
+              }
+            ],
+            "country_codes": [
+              "fr"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          -4.486588142435153,
+          48.415322590422875
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "geocoding": {
+          "id": "osm:node:305684983",
+          "type": "poi",
+          "label": "Carrefour City (Brest)",
+          "name": "Carrefour City",
+          "postcode": "29200",
+          "city": "Brest",
+          "citycode": "29019",
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:102430",
+              "insee": "29",
+              "level": 6,
+              "label": "Finist\u00e8re, Bretagne, France",
+              "name": "Finist\u00e8re",
+              "zip_codes": [],
+              "coord": {
+                "lon": -4.1024782,
+                "lat": 47.9960325
+              },
+              "bbox": [
+                -5.1440329,
+                47.7012815,
+                -3.3866547,
+                48.7538213
+              ],
+              "zone_type": "state_district",
+              "parent_id": "admin:osm:relation:102740",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-29"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR522"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q3389"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:102740",
+              "insee": "53",
+              "level": 4,
+              "label": "Bretagne, France",
+              "name": "Bretagne",
+              "zip_codes": [],
+              "coord": {
+                "lon": -1.6800198,
+                "lat": 48.1113387
+              },
+              "bbox": [
+                -5.1440329,
+                47.2777959,
+                -1.01569,
+                48.9086459
+              ],
+              "zone_type": "state",
+              "parent_id": "admin:osm:relation:2202162",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-BRE"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "53"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR52"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12130"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "bbox": [
+                -5.4517733,
+                41.261115499999995,
+                9.8282225,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:1076124",
+              "insee": "29019",
+              "level": 8,
+              "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+              "name": "Brest",
+              "zip_codes": [
+                "29200"
+              ],
+              "coord": {
+                "lon": -4.4860088,
+                "lat": 48.3905283
+              },
+              "bbox": [
+                -4.5689169,
+                48.3572972,
+                -4.4278311,
+                48.4595521
+              ],
+              "zone_type": "city",
+              "parent_id": "admin:osm:relation:102430",
+              "codes": [
+                {
+                  "name": "ref:FR:SIREN",
+                  "value": "212900195"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29019"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12193"
+                }
+              ]
+            }
+          ],
+          "poi_types": [
+            {
+              "id": "class_shop:subclass_convenience",
+              "name": "class_shop subclass_convenience"
+            }
+          ],
+          "properties": [
+            {
+              "key": "brand:wikipedia",
+              "value": "fr:Carrefour City"
+            },
+            {
+              "key": "shop",
+              "value": "convenience"
+            },
+            {
+              "key": "name_int",
+              "value": "Carrefour City"
+            },
+            {
+              "key": "brand:wikidata",
+              "value": "Q2940187"
+            },
+            {
+              "key": "name",
+              "value": "Carrefour City"
+            },
+            {
+              "key": "brand",
+              "value": "Carrefour City"
+            },
+            {
+              "key": "name:latin",
+              "value": "Carrefour City"
+            },
+            {
+              "key": "poi_subclass",
+              "value": "convenience"
+            },
+            {
+              "key": "poi_class",
+              "value": "shop"
+            }
+          ],
+          "address": {
+            "id": "addr:-4.486746;48.415313:53",
+            "type": "house",
+            "label": "53 Rue Marcellin Duval (Brest)",
+            "name": "53 Rue Marcellin Duval",
+            "housenumber": "53",
+            "street": "Rue Marcellin Duval",
+            "postcode": "29200",
+            "city": "Brest",
+            "citycode": "29019",
+            "administrative_regions": [
+              {
+                "id": "admin:osm:relation:102430",
+                "insee": "29",
+                "level": 6,
+                "label": "Finist\u00e8re, Bretagne, France",
+                "name": "Finist\u00e8re",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -4.1024782,
+                  "lat": 47.9960325
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.7012815,
+                  -3.3866547,
+                  48.7538213
+                ],
+                "zone_type": "state_district",
+                "parent_id": "admin:osm:relation:102740",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-29"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR522"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q3389"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:102740",
+                "insee": "53",
+                "level": 4,
+                "label": "Bretagne, France",
+                "name": "Bretagne",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -1.6800198,
+                  "lat": 48.1113387
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.2777959,
+                  -1.01569,
+                  48.9086459
+                ],
+                "zone_type": "state",
+                "parent_id": "admin:osm:relation:2202162",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-BRE"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "53"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR52"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12130"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:2202162",
+                "insee": "",
+                "level": 2,
+                "label": "France",
+                "name": "France",
+                "zip_codes": [],
+                "coord": {
+                  "lon": 2.3514616,
+                  "lat": 48.8566969
+                },
+                "bbox": [
+                  -5.4517733,
+                  41.261115499999995,
+                  9.8282225,
+                  51.3055721
+                ],
+                "zone_type": "country",
+                "parent_id": null,
+                "codes": [
+                  {
+                    "name": "ISO3166-1",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha2",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha3",
+                    "value": "FRA"
+                  },
+                  {
+                    "name": "ISO3166-1:numeric",
+                    "value": "250"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q142"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:1076124",
+                "insee": "29019",
+                "level": 8,
+                "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+                "name": "Brest",
+                "zip_codes": [
+                  "29200"
+                ],
+                "coord": {
+                  "lon": -4.4860088,
+                  "lat": 48.3905283
+                },
+                "bbox": [
+                  -4.5689169,
+                  48.3572972,
+                  -4.4278311,
+                  48.4595521
+                ],
+                "zone_type": "city",
+                "parent_id": "admin:osm:relation:102430",
+                "codes": [
+                  {
+                    "name": "ref:FR:SIREN",
+                    "value": "212900195"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29019"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12193"
+                  }
+                ]
+              }
+            ],
+            "country_codes": [
+              "fr"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          -4.473887128375367,
+          48.39172619188494
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "geocoding": {
+          "id": "osm:node:988637566",
+          "type": "poi",
+          "label": "Carrefour Express (Brest)",
+          "name": "Carrefour Express",
+          "postcode": null,
+          "city": "Brest",
+          "citycode": "29019",
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:1076124",
+              "insee": "29019",
+              "level": 8,
+              "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+              "name": "Brest",
+              "zip_codes": [
+                "29200"
+              ],
+              "coord": {
+                "lon": -4.4860088,
+                "lat": 48.3905283
+              },
+              "bbox": [
+                -4.5689169,
+                48.3572972,
+                -4.4278311,
+                48.4595521
+              ],
+              "zone_type": "city",
+              "parent_id": "admin:osm:relation:102430",
+              "codes": [
+                {
+                  "name": "ref:FR:SIREN",
+                  "value": "212900195"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29019"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12193"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:102430",
+              "insee": "29",
+              "level": 6,
+              "label": "Finist\u00e8re, Bretagne, France",
+              "name": "Finist\u00e8re",
+              "zip_codes": [],
+              "coord": {
+                "lon": -4.1024782,
+                "lat": 47.9960325
+              },
+              "bbox": [
+                -5.1440329,
+                47.7012815,
+                -3.3866547,
+                48.7538213
+              ],
+              "zone_type": "state_district",
+              "parent_id": "admin:osm:relation:102740",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-29"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR522"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q3389"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:102740",
+              "insee": "53",
+              "level": 4,
+              "label": "Bretagne, France",
+              "name": "Bretagne",
+              "zip_codes": [],
+              "coord": {
+                "lon": -1.6800198,
+                "lat": 48.1113387
+              },
+              "bbox": [
+                -5.1440329,
+                47.2777959,
+                -1.01569,
+                48.9086459
+              ],
+              "zone_type": "state",
+              "parent_id": "admin:osm:relation:2202162",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-BRE"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "53"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR52"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12130"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "bbox": [
+                -5.4517733,
+                41.261115499999995,
+                9.8282225,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ]
+            }
+          ],
+          "poi_types": [
+            {
+              "id": "class_shop:subclass_convenience",
+              "name": "class_shop subclass_convenience"
+            }
+          ],
+          "properties": [
+            {
+              "key": "brand:wikipedia",
+              "value": "fr:Carrefour Express"
+            },
+            {
+              "key": "addr:housenumber",
+              "value": "72"
+            },
+            {
+              "key": "name",
+              "value": "Carrefour Express"
+            },
+            {
+              "key": "shop",
+              "value": "convenience"
+            },
+            {
+              "key": "addr:street",
+              "value": "Rue Richelieu"
+            },
+            {
+              "key": "name:latin",
+              "value": "Carrefour Express"
+            },
+            {
+              "key": "operator",
+              "value": "Carrefour"
+            },
+            {
+              "key": "brand",
+              "value": "Carrefour Express"
+            },
+            {
+              "key": "name_int",
+              "value": "Carrefour Express"
+            },
+            {
+              "key": "opening_hours",
+              "value": "Mo-Sa 08:00-21:00; Su 09:00-13:00"
+            },
+            {
+              "key": "brand:wikidata",
+              "value": "Q2940190"
+            },
+            {
+              "key": "poi_subclass",
+              "value": "convenience"
+            },
+            {
+              "key": "poi_class",
+              "value": "shop"
+            }
+          ],
+          "address": {
+            "id": "addr_poi:osm:node:988637566",
+            "type": "house",
+            "label": "72 Rue Richelieu (Brest)",
+            "name": "72 Rue Richelieu",
+            "housenumber": "72",
+            "street": "Rue Richelieu",
+            "postcode": null,
+            "city": "Brest",
+            "citycode": "29019",
+            "administrative_regions": [
+              {
+                "id": "admin:osm:relation:1076124",
+                "insee": "29019",
+                "level": 8,
+                "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+                "name": "Brest",
+                "zip_codes": [
+                  "29200"
+                ],
+                "coord": {
+                  "lon": -4.4860088,
+                  "lat": 48.3905283
+                },
+                "bbox": [
+                  -4.5689169,
+                  48.3572972,
+                  -4.4278311,
+                  48.4595521
+                ],
+                "zone_type": "city",
+                "parent_id": "admin:osm:relation:102430",
+                "codes": [
+                  {
+                    "name": "ref:FR:SIREN",
+                    "value": "212900195"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29019"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12193"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:102430",
+                "insee": "29",
+                "level": 6,
+                "label": "Finist\u00e8re, Bretagne, France",
+                "name": "Finist\u00e8re",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -4.1024782,
+                  "lat": 47.9960325
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.7012815,
+                  -3.3866547,
+                  48.7538213
+                ],
+                "zone_type": "state_district",
+                "parent_id": "admin:osm:relation:102740",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-29"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR522"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q3389"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:102740",
+                "insee": "53",
+                "level": 4,
+                "label": "Bretagne, France",
+                "name": "Bretagne",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -1.6800198,
+                  "lat": 48.1113387
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.2777959,
+                  -1.01569,
+                  48.9086459
+                ],
+                "zone_type": "state",
+                "parent_id": "admin:osm:relation:2202162",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-BRE"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "53"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR52"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12130"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:2202162",
+                "insee": "",
+                "level": 2,
+                "label": "France",
+                "name": "France",
+                "zip_codes": [],
+                "coord": {
+                  "lon": 2.3514616,
+                  "lat": 48.8566969
+                },
+                "bbox": [
+                  -5.4517733,
+                  41.261115499999995,
+                  9.8282225,
+                  51.3055721
+                ],
+                "zone_type": "country",
+                "parent_id": null,
+                "codes": [
+                  {
+                    "name": "ISO3166-1",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha2",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha3",
+                    "value": "FRA"
+                  },
+                  {
+                    "name": "ISO3166-1:numeric",
+                    "value": "250"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q142"
+                  }
+                ]
+              }
+            ],
+            "country_codes": [
+              "FR"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          -4.468487841627109,
+          48.401967452639425
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "geocoding": {
+          "id": "osm:node:2140462910",
+          "type": "poi",
+          "label": "Carrefour Market (Brest)",
+          "name": "Carrefour Market",
+          "postcode": "29200",
+          "city": "Brest",
+          "citycode": "29019",
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:102430",
+              "insee": "29",
+              "level": 6,
+              "label": "Finist\u00e8re, Bretagne, France",
+              "name": "Finist\u00e8re",
+              "zip_codes": [],
+              "coord": {
+                "lon": -4.1024782,
+                "lat": 47.9960325
+              },
+              "bbox": [
+                -5.1440329,
+                47.7012815,
+                -3.3866547,
+                48.7538213
+              ],
+              "zone_type": "state_district",
+              "parent_id": "admin:osm:relation:102740",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-29"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR522"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q3389"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:102740",
+              "insee": "53",
+              "level": 4,
+              "label": "Bretagne, France",
+              "name": "Bretagne",
+              "zip_codes": [],
+              "coord": {
+                "lon": -1.6800198,
+                "lat": 48.1113387
+              },
+              "bbox": [
+                -5.1440329,
+                47.2777959,
+                -1.01569,
+                48.9086459
+              ],
+              "zone_type": "state",
+              "parent_id": "admin:osm:relation:2202162",
+              "codes": [
+                {
+                  "name": "ISO3166-2",
+                  "value": "FR-BRE"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "53"
+                },
+                {
+                  "name": "ref:NUTS",
+                  "value": "FR52"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12130"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "coord": {
+                "lon": 2.3514616,
+                "lat": 48.8566969
+              },
+              "bbox": [
+                -5.4517733,
+                41.261115499999995,
+                9.8282225,
+                51.3055721
+              ],
+              "zone_type": "country",
+              "parent_id": null,
+              "codes": [
+                {
+                  "name": "ISO3166-1",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha2",
+                  "value": "FR"
+                },
+                {
+                  "name": "ISO3166-1:alpha3",
+                  "value": "FRA"
+                },
+                {
+                  "name": "ISO3166-1:numeric",
+                  "value": "250"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q142"
+                }
+              ]
+            },
+            {
+              "id": "admin:osm:relation:1076124",
+              "insee": "29019",
+              "level": 8,
+              "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+              "name": "Brest",
+              "zip_codes": [
+                "29200"
+              ],
+              "coord": {
+                "lon": -4.4860088,
+                "lat": 48.3905283
+              },
+              "bbox": [
+                -4.5689169,
+                48.3572972,
+                -4.4278311,
+                48.4595521
+              ],
+              "zone_type": "city",
+              "parent_id": "admin:osm:relation:102430",
+              "codes": [
+                {
+                  "name": "ref:FR:SIREN",
+                  "value": "212900195"
+                },
+                {
+                  "name": "ref:INSEE",
+                  "value": "29019"
+                },
+                {
+                  "name": "wikidata",
+                  "value": "Q12193"
+                }
+              ]
+            }
+          ],
+          "poi_types": [
+            {
+              "id": "class_grocery:subclass_supermarket",
+              "name": "class_grocery subclass_supermarket"
+            }
+          ],
+          "properties": [
+            {
+              "key": "delivery:covid19",
+              "value": "no"
+            },
+            {
+              "key": "opening_hours",
+              "value": "Mo-Sa 07:00-22:00; Su 09:00-13:00"
+            },
+            {
+              "key": "name_int",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "name",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "opening_hours:covid19",
+              "value": "Su 09:00-13:00; Mo-Sa 07:30-20:00"
+            },
+            {
+              "key": "shop",
+              "value": "supermarket"
+            },
+            {
+              "key": "wheelchair",
+              "value": "yes"
+            },
+            {
+              "key": "brand:wikidata",
+              "value": "Q2689639"
+            },
+            {
+              "key": "takeaway:covid19",
+              "value": "only"
+            },
+            {
+              "key": "brand",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "brand:wikipedia",
+              "value": "fr:Carrefour Market"
+            },
+            {
+              "key": "name:latin",
+              "value": "Carrefour Market"
+            },
+            {
+              "key": "poi_subclass",
+              "value": "supermarket"
+            },
+            {
+              "key": "poi_class",
+              "value": "grocery"
+            }
+          ],
+          "address": {
+            "id": "addr:-4.468273;48.402004:268",
+            "type": "house",
+            "label": "268 Rue Jean Jaur\u00e8s (Brest)",
+            "name": "268 Rue Jean Jaur\u00e8s",
+            "housenumber": "268",
+            "street": "Rue Jean Jaur\u00e8s",
+            "postcode": "29200",
+            "city": "Brest",
+            "citycode": "29019",
+            "administrative_regions": [
+              {
+                "id": "admin:osm:relation:102430",
+                "insee": "29",
+                "level": 6,
+                "label": "Finist\u00e8re, Bretagne, France",
+                "name": "Finist\u00e8re",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -4.1024782,
+                  "lat": 47.9960325
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.7012815,
+                  -3.3866547,
+                  48.7538213
+                ],
+                "zone_type": "state_district",
+                "parent_id": "admin:osm:relation:102740",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-29"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR522"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q3389"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:102740",
+                "insee": "53",
+                "level": 4,
+                "label": "Bretagne, France",
+                "name": "Bretagne",
+                "zip_codes": [],
+                "coord": {
+                  "lon": -1.6800198,
+                  "lat": 48.1113387
+                },
+                "bbox": [
+                  -5.1440329,
+                  47.2777959,
+                  -1.01569,
+                  48.9086459
+                ],
+                "zone_type": "state",
+                "parent_id": "admin:osm:relation:2202162",
+                "codes": [
+                  {
+                    "name": "ISO3166-2",
+                    "value": "FR-BRE"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "53"
+                  },
+                  {
+                    "name": "ref:NUTS",
+                    "value": "FR52"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12130"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:2202162",
+                "insee": "",
+                "level": 2,
+                "label": "France",
+                "name": "France",
+                "zip_codes": [],
+                "coord": {
+                  "lon": 2.3514616,
+                  "lat": 48.8566969
+                },
+                "bbox": [
+                  -5.4517733,
+                  41.261115499999995,
+                  9.8282225,
+                  51.3055721
+                ],
+                "zone_type": "country",
+                "parent_id": null,
+                "codes": [
+                  {
+                    "name": "ISO3166-1",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha2",
+                    "value": "FR"
+                  },
+                  {
+                    "name": "ISO3166-1:alpha3",
+                    "value": "FRA"
+                  },
+                  {
+                    "name": "ISO3166-1:numeric",
+                    "value": "250"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q142"
+                  }
+                ]
+              },
+              {
+                "id": "admin:osm:relation:1076124",
+                "insee": "29019",
+                "level": 8,
+                "label": "Brest (29200), Finist\u00e8re, Bretagne, France",
+                "name": "Brest",
+                "zip_codes": [
+                  "29200"
+                ],
+                "coord": {
+                  "lon": -4.4860088,
+                  "lat": 48.3905283
+                },
+                "bbox": [
+                  -4.5689169,
+                  48.3572972,
+                  -4.4278311,
+                  48.4595521
+                ],
+                "zone_type": "city",
+                "parent_id": "admin:osm:relation:102430",
+                "codes": [
+                  {
+                    "name": "ref:FR:SIREN",
+                    "value": "212900195"
+                  },
+                  {
+                    "name": "ref:INSEE",
+                    "value": "29019"
+                  },
+                  {
+                    "name": "wikidata",
+                    "value": "Q12193"
+                  }
+                ]
+              }
+            ],
+            "country_codes": [
+              "fr"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -1,24 +1,16 @@
-import os
 import re
 import pytest
-import json
-from functools import partial
 from unittest.mock import ANY
-import respx
 from starlette.testclient import TestClient
 
 from app import app
-from .utils import enable_pj_source, override_settings
+from .utils import enable_pj_source, override_settings, read_fixture
 
 
 BASE_URL = "http://qwant.bragi"
 NLU_URL = "http://qwant.nlu/"
 CLASSIF_URL = "http://qwant.classif"
 ES_URL = "http://qwant.es"
-
-
-def read_fixture(sPath):
-    return json.load(open(os.path.join(os.path.dirname(__file__), sPath)))
 
 
 FIXTURE_AUTOCOMPLETE = read_fixture("fixtures/autocomplete/pavillon_paris.json")
@@ -28,12 +20,6 @@ FIXTURE_TOKENIZER = {
     dataset: read_fixture(f"fixtures/autocomplete/nlu/{dataset}.json")
     for dataset in ["with_brand", "with_brand_and_country", "with_cat", "with_country", "with_poi"]
 }
-
-
-@pytest.fixture
-def httpx_mock():
-    with respx.mock(assert_all_called=False) as rsps:
-        yield rsps
 
 
 def mock_NLU_for(httpx_mock, dataset):

--- a/tests/test_places_by_query.py
+++ b/tests/test_places_by_query.py
@@ -1,0 +1,46 @@
+import re
+import pytest
+from app import app
+from starlette.testclient import TestClient
+from freezegun import freeze_time
+
+from .utils import read_fixture, override_settings
+
+BBOX = "-4.5689169,48.3572972,-4.4278311,48.4595521"
+BRAGI_BASE_URL = "http://bragi.test"
+BRAGI_RESPONSE = read_fixture("fixtures/autocomplete/carrefour_in_bbox.json")
+
+
+@pytest.fixture
+def mock_autocomplete_post(httpx_mock):
+    with override_settings({"BRAGI_BASE_URL": BRAGI_BASE_URL}):
+        httpx_mock.post(re.compile(f"^{BRAGI_BASE_URL}/autocomplete"), content=BRAGI_RESPONSE)
+        yield
+
+
+@freeze_time("2020-05-14 08:30:00+02:00")
+def test_places_bbox_with_osm_query(mock_autocomplete_post):
+    """
+        Test the bbox query:
+        Query first all categories in fixtures with bbox that excludes the patisserie POI
+        We should have 5 POI results including: blancs_manteaux, orsay and louvre, but not patisserie_peron (not in bbox)
+    """
+    client = TestClient(app)
+
+    response = client.get(url=f"http://localhost/v1/places?bbox={BBOX}&q=carrefour&source=osm")
+
+    assert response.status_code == 200
+
+    resp = response.json()
+    places = resp["places"]
+    assert len(places) == 5
+
+    assert places[0]["name"] == "Carrefour Market"
+    assert places[0]["address"]["label"] == "Rue Pierre Trépos (Brest)"
+    assert places[0]["address"]["housenumber"] is None
+    assert places[0]["address"]["country_code"] == "FR"
+
+    assert places[1]["name"] == "Carrefour"
+    assert places[1]["address"]["label"] == "120 Boulevard de Plymouth (Brest)"
+    assert places[1]["address"]["housenumber"] == "120"
+    assert places[1]["address"]["country_code"] == "FR"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+import os
+import json
 from contextlib import contextmanager
 from copy import deepcopy
 
@@ -59,3 +61,7 @@ def enable_weather_api():
         }
     ):
         yield
+
+
+def read_fixture(fixture_path):
+    return json.load(open(os.path.join(os.path.dirname(__file__), fixture_path)))


### PR DESCRIPTION
Search for places with `bbox` and full-text query `q` is now possible among OSM data !

A few notes:

* this PR defines `pois_query_in_bbox` to use Bragi's `POST /autocomplete` with a geojson shape in body to filter search results contained in bbox.

* `get_places_bbox` endpoint is now async to call the `BragiClient`. FastAPI's `run_in_threadpool` is used to call pre-existing I/O-blocking functions in separate threads.

* a new `BragiPOI` adapter is required, as the POI format returned by Bragi is slightly different than raw data stored in Elasticsearch. This part is quite ugly.  
In the longer term, we could consider implementing all bbox searches with Bragi.
But this would require some delicate changes about how class/subclass filters are implemented.
