### PR TITLE
NLU: allow full-text query outside France and without focus

### DIFF
--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -123,7 +123,7 @@ class NLU_Helper:
                 description={"query": cat_query, "place": place},
             )
 
-    async def build_intention_category(self, cat_query, lang, skip_classifier=False, focus=None):
+    async def build_intention_category(self, cat_query, lang, skip_classifier=False):
         category_name = None
 
         if not skip_classifier:
@@ -133,10 +133,7 @@ class NLU_Helper:
             return Intention(
                 filter={"category": category_name}, description={"category": category_name},
             )
-        elif focus and pj_source.point_is_covered(focus):
-            return Intention(filter={"q": cat_query}, description={"query": cat_query})
-
-        return None
+        return Intention(filter={"q": cat_query}, description={"query": cat_query})
 
     @classmethod
     def is_poi_request(cls, tags_list):
@@ -212,7 +209,7 @@ class NLU_Helper:
             else:
                 # 1 category or brand
                 intention = await self.build_intention_category(
-                    cat_or_brand_query, lang=lang, skip_classifier=skip_classifier, focus=focus
+                    cat_or_brand_query, lang=lang, skip_classifier=skip_classifier
                 )
                 if intention is not None:
                     # A query tagged as "category" and not recognized by the classifier often

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -115,13 +115,9 @@ class NLU_Helper:
                 filter={"category": category_name, "bbox": bbox},
                 description={"category": category_name, "place": place},
             )
-        else:
-            if not pj_source.bbox_is_covered(bbox):
-                return None
-            return Intention(
-                filter={"q": cat_query, "bbox": bbox},
-                description={"query": cat_query, "place": place},
-            )
+        return Intention(
+            filter={"q": cat_query, "bbox": bbox}, description={"query": cat_query, "place": place}
+        )
 
     async def build_intention_category(self, cat_query, lang, skip_classifier=False):
         category_name = None

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -186,7 +186,7 @@ def test_autocomplete_with_nlu_brand_no_focus(mock_autocomplete_get, mock_NLU_wi
     assert_ok_with(
         client,
         params={"q": "auchan", "lang": "fr", "limit": 7, "nlu": True},
-        expected_intention=[{"filter": {"q": "auchan"}, "description": {"query": "auchan"},}],
+        expected_intention=[{"filter": {"q": "auchan"}, "description": {"query": "auchan"}}],
         expected_intention_place=None,
     )
 

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -186,7 +186,7 @@ def test_autocomplete_with_nlu_brand_no_focus(mock_autocomplete_get, mock_NLU_wi
     assert_ok_with(
         client,
         params={"q": "auchan", "lang": "fr", "limit": 7, "nlu": True},
-        expected_intention=[],
+        expected_intention=[{"filter": {"q": "auchan"}, "description": {"query": "auchan"},}],
         expected_intention_place=None,
     )
 


### PR DESCRIPTION
In the first implementation, an `Intention` with full-text query was returned only when `pj_source` was available for the current focus point (i.e in France).

Now that #134 introduces full-text queries for all data sources, this condition can be removed. 

As a consequence, a query with a brand name may also be returned if no focus is set. We need to check if this behavior is expected and that the front-end application will behave correctly in this case.