### PR TITLE
Redirect unknown address id to equivalent latlon

### DIFF
--- a/idunn/places/exceptions.py
+++ b/idunn/places/exceptions.py
@@ -3,3 +3,8 @@ class InvalidPlaceId(ValueError):
         self.id = place_id
         self.message = f"Invalid place id: '{place_id}'"
         super().__init__(self.message)
+
+
+class RedirectToPlaceId(Exception):
+    def __init__(self, target_id):
+        self.target_id = target_id

--- a/idunn/places/utils.py
+++ b/idunn/places/utils.py
@@ -1,14 +1,16 @@
+from fastapi import HTTPException
 from idunn.api.pages_jaunes import pj_source
 from idunn.utils.es_wrapper import get_elasticsearch
-from idunn.api.utils import fetch_es_place
+from idunn.api.utils import fetch_es_place, PlaceNotFound
 from idunn.utils import prometheus
+
 
 from .admin import Admin
 from .street import Street
 from .address import Address
 from .poi import POI
 from .latlon import Latlon
-from .exceptions import InvalidPlaceId
+from .exceptions import InvalidPlaceId, RedirectToPlaceId
 
 
 def place_from_id(id, type=None):
@@ -18,7 +20,7 @@ def place_from_id(id, type=None):
     :return: Place
     """
     try:
-        namespace, _ = id.split(":", 1)
+        namespace, suffix = id.split(":", 1)
     except ValueError:
         raise InvalidPlaceId(id)
 
@@ -30,9 +32,24 @@ def place_from_id(id, type=None):
     if namespace == Latlon.PLACE_ID_NAMESPACE:
         return Latlon.from_id(id)
 
-    #  Otherwise handle places from the ES db
+    # Otherwise handle places from the ES db
     es = get_elasticsearch()
-    es_place = fetch_es_place(id, es, type)
+
+    try:
+        es_place = fetch_es_place(id, es, type)
+    except PlaceNotFound as e:
+        if namespace == "addr":
+            # A Latlon place can be used as a substitute for a "addr:<lon>;<lat>" id
+            # that is not present in the database anymore
+            try:
+                lon, lat = suffix.split(":", 1)[0].split(";")
+                latlon_id = Latlon(lat=lat, lon=lon).get_id()
+            except ValueError:
+                pass
+            else:
+                raise RedirectToPlaceId(latlon_id)
+        raise HTTPException(status_code=404, detail=e.message)
+
     places = {
         "admin": Admin,
         "street": Street,


### PR DESCRIPTION
Ids for addresses currently use this pattern: `addr:<lon>;<lat>:<house_number>`.  
They may not be stable in the long term, especially if multiple data sources are used to import addresses, or because of rounding discrepancies. 

This PR suggests to redirect requests about unknown `addr:` objects to equivalent `latlon:` objects (where reverse geocoding may be used) when `lat` and `lon` values can be extracted from their id.  
In this case a HTTP 303 ("See other") response is returned.

