### PR TITLE
Ignore trailing slash in url prefix used for redirected location

### DIFF
--- a/idunn/api/places.py
+++ b/idunn/api/places.py
@@ -90,7 +90,7 @@ def get_place(
     except InvalidPlaceId as e:
         raise HTTPException(status_code=404, detail=e.message)
     except RedirectToPlaceId as e:
-        path_prefix = request.headers.get("x-forwarded-prefix", "")
+        path_prefix = request.headers.get("x-forwarded-prefix", "").rstrip("/")
         path = request.app.url_path_for("get_place", id=e.target_id)
         query = request.url.query
         return JSONResponse(

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -505,6 +505,17 @@ def test_redirect_obsolete_address_with_lat_lon():
     assert response.headers["location"] == "/v1/places/latlon:45.60000:-1.12000?lang=fr"
 
 
+def test_redirect_obsolete_address_with_url_prefix():
+    client = TestClient(app)
+    response = client.get(
+        url="http://localhost/v1/places/addr:-1.12;45.6?lang=fr",
+        headers={"x-forwarded-prefix": "/maps/detail/"},
+        allow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/maps/detail/v1/places/latlon:45.60000:-1.12000?lang=fr"
+
+
 def test_basic_short_query_poi():
     client = TestClient(app)
     response = client.get(


### PR DESCRIPTION
A small oversight to fix, following #137 

Trailing slashes are actually not a problem in this case, but it would be cleaner to avoid successive `//` in the redirected URL.