### PR TITLE
add a circuit breaker for NLU API's

### DIFF
--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -35,7 +35,9 @@ class WikipediaSession:
     API_PHP_BASE_PATTERN = "https://{lang}.wikipedia.org/w/api.php"
 
     circuit_breaker = IdunnCircuitBreaker(
-        "wikipedia_api_breaker", settings["WIKI_BREAKER_MAXFAIL"], settings["WIKI_BREAKER_TIMEOUT"]
+        "wikipedia_api_breaker",
+        int(settings["WIKI_BREAKER_MAXFAIL"]),
+        int(settings["WIKI_BREAKER_TIMEOUT"]),
     )
 
     class Helpers:

--- a/idunn/blocks/wikipedia.py
+++ b/idunn/blocks/wikipedia.py
@@ -34,7 +34,9 @@ class WikipediaSession:
     API_V1_BASE_PATTERN = "https://{lang}.wikipedia.org/api/rest_v1"
     API_PHP_BASE_PATTERN = "https://{lang}.wikipedia.org/w/api.php"
 
-    circuit_breaker = IdunnCircuitBreaker(name="wikipedia_api_breaker")
+    circuit_breaker = IdunnCircuitBreaker(
+        "wikipedia_api_breaker", settings["WIKI_BREAKER_MAXFAIL"], settings["WIKI_BREAKER_TIMEOUT"]
+    )
 
     class Helpers:
         @staticmethod

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -23,12 +23,15 @@ NLU_CATEGORY_TAGS = ["cat"]
 NLU_PLACE_TAGS = ["city", "country", "state", "street"]
 
 tagger_circuit_breaker = IdunnCircuitBreaker(
-    "nlu_tagger_api_breaker", settings["NLU_BREAKER_MAXFAIL"], settings["NLU_BREAKER_TIMEOUT"],
+    "nlu_tagger_api_breaker",
+    int(settings["NLU_BREAKER_MAXFAIL"]),
+    int(settings["NLU_BREAKER_TIMEOUT"]),
 )
+
 classifier_circuit_breaker = IdunnCircuitBreaker(
     "classifier_tagger_api_breaker",
-    settings["NLU_BREAKER_MAXFAIL"],
-    settings["NLU_BREAKER_TIMEOUT"],
+    int(settings["NLU_BREAKER_MAXFAIL"]),
+    int(settings["NLU_BREAKER_TIMEOUT"]),
 )
 
 

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -22,8 +22,14 @@ NLU_BRAND_TAGS = ["brand"]
 NLU_CATEGORY_TAGS = ["cat"]
 NLU_PLACE_TAGS = ["city", "country", "state", "street"]
 
-tagger_circuit_breaker = IdunnCircuitBreaker(name="nlu_tagger_api_breaker")
-classifier_circuit_breaker = IdunnCircuitBreaker(name="classifier_tagger_api_breaker")
+tagger_circuit_breaker = IdunnCircuitBreaker(
+    "nlu_tagger_api_breaker", settings["NLU_BREAKER_MAXFAIL"], settings["NLU_BREAKER_TIMEOUT"],
+)
+classifier_circuit_breaker = IdunnCircuitBreaker(
+    "classifier_tagger_api_breaker",
+    settings["NLU_BREAKER_MAXFAIL"],
+    settings["NLU_BREAKER_TIMEOUT"],
+)
 
 
 class NLU_Helper:

--- a/idunn/utils/circuit_breaker.py
+++ b/idunn/utils/circuit_breaker.py
@@ -26,8 +26,8 @@ class LogListener(pybreaker.CircuitBreakerListener):
 class IdunnCircuitBreaker(pybreaker.CircuitBreaker):
     def __init__(self, name, fail_max, reset_timeout):
         super().__init__(
-            fail_max=fail_max,
-            reset_timeout=reset_timeout,
+            fail_max=int(fail_max),
+            reset_timeout=int(reset_timeout),
             exclude=[is_http_client_error],
             listeners=[LogListener()],
             name=name,

--- a/idunn/utils/circuit_breaker.py
+++ b/idunn/utils/circuit_breaker.py
@@ -2,8 +2,6 @@ import pybreaker
 import logging
 from requests import HTTPError
 
-from idunn import settings
-
 logger = logging.getLogger(__name__)
 
 
@@ -24,10 +22,10 @@ class LogListener(pybreaker.CircuitBreakerListener):
 
 
 class IdunnCircuitBreaker(pybreaker.CircuitBreaker):
-    def __init__(self, name):
+    def __init__(self, name, fail_max, reset_timeout):
         super().__init__(
-            fail_max=settings["CIRCUIT_BREAKER_MAXFAIL"],
-            reset_timeout=settings["CIRCUIT_BREAKER_TIMEOUT"],
+            fail_max=fail_max,
+            reset_timeout=reset_timeout,
             exclude=[is_http_client_error],
             listeners=[LogListener()],
             name=name,

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -19,6 +19,9 @@ WIKI_API_REDIS_URL: # DEPRECATED. Use REDIS_URL instead
 WIKI_CACHE_REDIS_DB: 1
 WIKI_CACHE_TIMEOUT: 86400 # seconds
 
+WIKI_BREAKER_TIMEOUT: 120 # timeout period in seconds
+WIKI_BREAKER_MAXFAIL: 20 # consecutive failures before breaking
+
 LOG_LEVEL_BY_MODULE: '{"": "info", "elasticsearch": "warning"}' # json config to set, for each module a log level
 LOG_FORMAT: '[%(asctime)s] [%(levelname)5s] [%(process)5s] [%(name)10s] %(message)s' # logging format. if the log are json, it list the default fields
 LOG_JSON: False  # To get flat logs or json logs
@@ -49,12 +52,6 @@ LIST_PLACES_MAX_SIZE: 50
 ## Redis
 REDIS_URL:
 REDIS_TIMEOUT: "0.3" # seconds
-
-
-########################
-## Circuit Breaker
-CIRCUIT_BREAKER_TIMEOUT: 120 # timeout period in seconds
-CIRCUIT_BREAKER_MAXFAIL: 20 # consecutive failures before breaking
 
 ########################
 ## Rate Limiter
@@ -115,6 +112,9 @@ BRAGI_BASE_URL: "http://bragi:4000"
 AUTOCOMPLETE_NLU_DEFAULT: False
 NLU_TAGGER_URL:
 NLU_CLASSIFIER_URL:
+
+NLU_BREAKER_TIMEOUT: 60 # timeout period in seconds
+NLU_BREAKER_MAXFAIL: 5 # consecutive failures before breaking
 
 #######################
 ## OpenAPI DOCS

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -113,7 +113,7 @@ AUTOCOMPLETE_NLU_DEFAULT: False
 NLU_TAGGER_URL:
 NLU_CLASSIFIER_URL:
 
-NLU_BREAKER_TIMEOUT: 60 # timeout period in seconds
+NLU_BREAKER_TIMEOUT: 120 # timeout period in seconds
 NLU_BREAKER_MAXFAIL: 5 # consecutive failures before breaking
 
 #######################


### PR DESCRIPTION
Implement a circuit breaker for NLU endpoints.

This shares the same behavior as Wikipedia's circuit breaker which means:

 - ~~it shares the same settings for timeout (defaults to 120s) and max fails (defaults to 20), it would need more changes to be able to customize this (but I don't think we actually care?)~~

 - when the max tries are reached without success, the API calls will be skipped until the timeout is elapsed, then the next call will trigger the timer again if it fails again

I did override the `call_async` method from pybreaker, which should not be helpful in Idunn since it appears it is only [compatible with the asyncs from Tornado framework](https://pypi.org/project/pybreaker/#optional-tornado-support).