### PR TITLE
Covid-19: exclude block from response if opening status is 'unknown'

### DIFF
--- a/idunn/blocks/covid19.py
+++ b/idunn/blocks/covid19.py
@@ -49,7 +49,6 @@ class Covid19Block(BaseBlock):
             return None
 
         properties = es_poi.properties
-        # Check if this is a french admin, otherwise we return nothing.
         if es_poi.get_country_code() not in COVID19_BLOCK_COUNTRIES:
             return None
 
@@ -96,7 +95,7 @@ class Covid19Block(BaseBlock):
         elif raw_opening_hours is not None:
             opening_hours = parse_time_block(OpeningHourBlock, es_poi, lang, raw_opening_hours)
             if opening_hours is None:
-                status = "unknown"
+                status = CovidOpeningStatus.unknown
             elif opening_hours.status in ["open", "closed"]:
                 if raw_opening_hours == properties.get("opening_hours"):
                     status = CovidOpeningStatus.open_as_usual
@@ -104,6 +103,12 @@ class Covid19Block(BaseBlock):
                     status = CovidOpeningStatus.open
             else:
                 status = CovidOpeningStatus.maybe_open
+
+        if (
+            status == CovidOpeningStatus.unknown
+            and not settings["COVID19_BLOCK_KEEP_STATUS_UNKNOWN"]
+        ):
+            return None
 
         return cls(
             status=status, note=note, opening_hours=opening_hours, contribute_url=contribute_url

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -128,6 +128,7 @@ COVID19_OSM_DATASET_URL: https://www.data.gouv.fr/fr/datasets/r/3ed2f2eb-11a0-44
 COVID19_OSM_DATASET_EXPIRE: 7200 # seconds
 COVID19_POI_EXPIRE: 86400 # seconds
 COVID19_BLOCK_COUNTRIES: "FR" # comma separated list
+COVID19_BLOCK_KEEP_STATUS_UNKNOWN: False # Whether covid19 block is returned when no specific data is available
 
 ########################
 ## Recycling data

--- a/tests/test_covid19.py
+++ b/tests/test_covid19.py
@@ -22,6 +22,17 @@ def test_covid19_block():
     assert covid19_block["opening_hours"] is not None
 
 
+def test_covid19_block_unknown_status():
+    with override_settings({"BLOCK_COVID_ENABLED": True, "COVID19_USE_REDIS_DATASET": False}):
+        client = TestClient(app)
+        response = client.get(url=f"http://localhost/v1/pois/osm:node:36153811?lang=fr")
+
+    assert response.status_code == 200
+    resp = response.json()
+    covid19_block = next((b for b in resp["blocks"] if b["type"] == "covid19"), None)
+    assert covid19_block is None, "Block 'covid19' should not be returned"
+
+
 @freeze_time("2020-04-23 12:00:00+02:00")
 @patch.object(POI, "get_country_code", lambda *x: "FR")
 def test_covid19_parse_hours():


### PR DESCRIPTION
This PR implements a new flag `COVID19_BLOCK_KEEP_STATUS_UNKNOWN`, False by default.

As a consequence, the block `covid19` will no longer be returned about POIs for which no specific data is available (i.e. when the `status` in this block is `unknown`).