### PR TITLE
Recycling: Configure measures max age

### DIFF
--- a/idunn/blocks/recycling.py
+++ b/idunn/blocks/recycling.py
@@ -56,7 +56,7 @@ class RecyclingBlock(BaseBlock):
 
     @classmethod
     def from_es(cls, place, lang):
-        if not settings.get("RECYCLING_SERVER_URL"):
+        if not recycling_client.enabled:
             # Data source is not configured
             return None
 

--- a/idunn/datasources/recycling.py
+++ b/idunn/datasources/recycling.py
@@ -18,6 +18,7 @@ class RecyclingDataSource:
         self.data_collection = settings["RECYCLING_DATA_COLLECTION"]
         self.use_cache = settings["RECYCLING_DATA_STORE_IN_CACHE"]
         self.cache_expire = int(settings["RECYCLING_DATA_EXPIRE"])
+        self.measures_max_age_in_hours = int(settings["RECYCLING_MEASURES_MAX_AGE_IN_HOURS"])
 
         self._token_expires_at = 0
 
@@ -82,7 +83,7 @@ class RecyclingDataSource:
         query = {
             "bool": {
                 "filter": [
-                    {"range": {"hour": {"gte": "now-7d"}}},
+                    {"range": {"hour": {"gte": f"now-{self.measures_max_age_in_hours}h"}}},
                     {
                         "nested": {
                             "path": "metadata.location",

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -141,3 +141,4 @@ RECYCLING_DATA_COLLECTION: "hourly"
 RECYCLING_MAX_DISTANCE_AROUND_POI: 100 # meters
 RECYCLING_DATA_STORE_IN_CACHE: True # Recycling data will be cached if Redis is configured
 RECYCLING_DATA_EXPIRE: 1800 # seconds
+RECYCLING_MEASURES_MAX_AGE_IN_HOURS: 336 # = 14 days (Older measures will be ignored)


### PR DESCRIPTION
Implement `RECYCLING_MEASURES_MAX_AGE_IN_HOURS` in settings.  
Measures older than this threshold will be filtered out by the query to the data source.