### PR TITLE
Upgrade to fastapi 0.55.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ black = "==19.10b0"
 respx = "*"
 
 [packages]
-fastapi="==0.46.*"
+fastapi="==0.55.*"
 elasticsearch = ">=2.0.0,<3.0.0"
 requests = ">=2.20.0"
 tzwhere = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "50668c81c1203b53176c46db696be108a64720e4ffc8caa603cdad7b324b6851"
+            "sha256": "aea0f088a116cd2db6e293d8fc7710715c2964bf335ae882e6c3d8b73c35935d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,10 +34,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1",
+                "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.4.5.2"
         },
         "chardet": {
             "hashes": [
@@ -71,11 +71,11 @@
         },
         "fastapi": {
             "hashes": [
-                "sha256:6c9b919f2ed742d2ad78e6dce5ad1be761e67292b838ba114cb525ec784d10a1",
-                "sha256:7f8d795be11e21675b6843424b378fe2ec95a14cecba1c53c68471412cca28c7"
+                "sha256:912bc1a1b187146fd74dd45e17ea10aede3d962c921142c412458e911c50dc4c",
+                "sha256:b1a96ea772f10cd0235eb09d6e282b1f5e6135dad5121ed80d6beb8fa932e075"
             ],
             "index": "pypi",
-            "version": "==0.46.0"
+            "version": "==0.55.1"
         },
         "geographiclib": {
             "hashes": [
@@ -123,10 +123,10 @@
         },
         "hstspreload": {
             "hashes": [
-                "sha256:5f9782b70f884eaaf2297872e73b8ada122d538bb7bdc41382a9fdfb2d61eb61",
-                "sha256:ca6a3556ac40674e0663f7787a1c48acbef0ba3e262458ea8a149bebd32841f6"
+                "sha256:1534715db2f5224debb605a82e3f79ee9f891031b748cdcf0441eb672d5f3aa2",
+                "sha256:697987b7e849f315e5c4625cab662b390e991e7ef951884aa6013106c9c48000"
             ],
-            "version": "==2020.6.2"
+            "version": "==2020.6.9"
         },
         "httpcore": {
             "hashes": [
@@ -189,11 +189,11 @@
         },
         "phonenumbers": {
             "hashes": [
-                "sha256:46c5997fe076026aa2d4b66d0c53eea4babae2e808e8a5f39c09e2dfa6612d08",
-                "sha256:c6c43d6459aac85b646d6b7a7ab79b3b629eb168f0e9b851b331e2e5872bbd01"
+                "sha256:3586f19abeb92aa6b539d7a4757cb507cf54efcd78224e895caf20fbdde07c26",
+                "sha256:67199749bbc5cb7c3a09f623e29f23dc294df6582968841f1ca2acbc06faafc1"
             ],
             "index": "pypi",
-            "version": "==8.12.4"
+            "version": "==8.12.5"
         },
         "prometheus-client": {
             "hashes": [
@@ -333,9 +333,10 @@
         },
         "starlette": {
             "hashes": [
-                "sha256:c2ac9a42e0e0328ad20fe444115ac5e3760c1ee2ac1ff8cdb5ec915c4a453411"
+                "sha256:6169ee78ded501095d1dda7b141a1dc9f9934d37ad23196e180150ace2c6449b",
+                "sha256:a9bb130fa7aa736eda8a814b6ceb85ccf7a209ed53843d0d61e246b380afa10f"
             ],
-            "version": "==0.12.9"
+            "version": "==0.13.2"
         },
         "tzwhere": {
             "hashes": [
@@ -434,10 +435,10 @@
         },
         "backcall": {
             "hashes": [
-                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
-                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+                "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
+                "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
             ],
-            "version": "==0.1.0"
+            "version": "==0.2.0"
         },
         "black": {
             "hashes": [
@@ -449,10 +450,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1",
+                "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.4.5.2"
         },
         "chardet": {
             "hashes": [
@@ -506,10 +507,10 @@
         },
         "hstspreload": {
             "hashes": [
-                "sha256:5f9782b70f884eaaf2297872e73b8ada122d538bb7bdc41382a9fdfb2d61eb61",
-                "sha256:ca6a3556ac40674e0663f7787a1c48acbef0ba3e262458ea8a149bebd32841f6"
+                "sha256:1534715db2f5224debb605a82e3f79ee9f891031b748cdcf0441eb672d5f3aa2",
+                "sha256:697987b7e849f315e5c4625cab662b390e991e7ef951884aa6013106c9c48000"
             ],
-            "version": "==2020.6.2"
+            "version": "==2020.6.9"
         },
         "httpcore": {
             "hashes": [
@@ -672,29 +673,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:1386e75c9d1574f6aa2e4eb5355374c8e55f9aac97e224a8a5a6abded0f9c927",
-                "sha256:27ff7325b297fb6e5ebb70d10437592433601c423f5acf86e5bc1ee2919b9561",
-                "sha256:329ba35d711e3428db6b45a53b1b13a0a8ba07cbbcf10bbed291a7da45f106c3",
-                "sha256:3a9394197664e35566242686d84dfd264c07b20f93514e2e09d3c2b3ffdf78fe",
-                "sha256:51f17abbe973c7673a61863516bdc9c0ef467407a940f39501e786a07406699c",
-                "sha256:579ea215c81d18da550b62ff97ee187b99f1b135fd894a13451e00986a080cad",
-                "sha256:70c14743320a68c5dac7fc5a0f685be63bc2024b062fe2aaccc4acc3d01b14a1",
-                "sha256:7e61be8a2900897803c293247ef87366d5df86bf701083b6c43119c7c6c99108",
-                "sha256:8044d1c085d49673aadb3d7dc20ef5cb5b030c7a4fa253a593dda2eab3059929",
-                "sha256:89d76ce33d3266173f5be80bd4efcbd5196cafc34100fdab814f9b228dee0fa4",
-                "sha256:99568f00f7bf820c620f01721485cad230f3fb28f57d8fbf4a7967ec2e446994",
-                "sha256:a7c37f048ec3920783abab99f8f4036561a174f1314302ccfa4e9ad31cb00eb4",
-                "sha256:c2062c7d470751b648f1cacc3f54460aebfc261285f14bc6da49c6943bd48bdd",
-                "sha256:c9bce6e006fbe771a02bda468ec40ffccbf954803b470a0345ad39c603402577",
-                "sha256:ce367d21f33e23a84fb83a641b3834dd7dd8e9318ad8ff677fbfae5915a239f7",
-                "sha256:ce450ffbfec93821ab1fea94779a8440e10cf63819be6e176eb1973a6017aff5",
-                "sha256:ce5cc53aa9fbbf6712e92c7cf268274eaff30f6bd12a0754e8133d85a8fb0f5f",
-                "sha256:d466967ac8e45244b9dfe302bbe5e3337f8dc4dec8d7d10f5e950d83b140d33a",
-                "sha256:d881c2e657c51d89f02ae4c21d9adbef76b8325fe4d5cf0e9ad62f850f3a98fd",
-                "sha256:e565569fc28e3ba3e475ec344d87ed3cd8ba2d575335359749298a0899fe122e",
-                "sha256:ea55b80eb0d1c3f1d8d784264a6764f931e172480a2f1868f2536444c5f01e01"
+                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
+                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
+                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
+                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
+                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
+                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
+                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
+                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
+                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
+                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
+                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
+                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
+                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
+                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
+                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
+                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
+                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
+                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
+                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
+                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
+                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
             ],
-            "version": "==2020.5.14"
+            "version": "==2020.6.8"
         },
         "requests": {
             "hashes": [
@@ -790,10 +791,10 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:980fbf4f3c196c0f329cdcd1e84c554d6a211f18e252e525a0cf4223154a41d6",
-                "sha256:edbc2b718b4db6cdf393eefe3a420183947d6aa312505ce6754516f458ff8830"
+                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
+                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
             ],
-            "version": "==0.2.3"
+            "version": "==0.2.4"
         }
     }
 }

--- a/app.py
+++ b/app.py
@@ -2,10 +2,9 @@ from idunn import settings
 from idunn.api.urls import get_api_urls
 from idunn.utils.encoders import override_datetime_encoder
 from idunn.utils.prometheus import handle_errors
-from fastapi import FastAPI, APIRouter
+from fastapi import FastAPI, APIRouter, Request
 from fastapi.exceptions import RequestValidationError
-from starlette.requests import Request
-from starlette.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse
 import uvicorn
 
 

--- a/idunn/api/directions.py
+++ b/idunn/api/directions.py
@@ -1,6 +1,4 @@
-from fastapi import HTTPException, Query, Depends
-from starlette.requests import Request
-from starlette.responses import Response
+from fastapi import HTTPException, Query, Depends, Request, Response
 
 from idunn import settings
 from idunn.places import Latlon, place_from_id, InvalidPlaceId

--- a/idunn/api/places.py
+++ b/idunn/api/places.py
@@ -1,10 +1,9 @@
 import logging
 import urllib.parse
-
-from fastapi import HTTPException, BackgroundTasks
-from starlette.responses import Response, JSONResponse
-from starlette.requests import Request
 from starlette.datastructures import URL
+from fastapi import HTTPException, BackgroundTasks, Request, Response
+from fastapi.responses import JSONResponse
+
 
 from idunn import settings
 from idunn.utils.es_wrapper import get_elasticsearch

--- a/idunn/directions/client.py
+++ b/idunn/directions/client.py
@@ -1,9 +1,9 @@
 import requests
 import logging
 from datetime import datetime, timedelta
-from starlette.responses import JSONResponse
 from starlette.requests import QueryParams
 from fastapi import HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional
 

--- a/idunn/directions/models.py
+++ b/idunn/directions/models.py
@@ -182,7 +182,8 @@ class DirectionsRoute(BaseModel):
     geometry: dict = Field({}, description="GeoJSON")
 
     def __init__(self, **data):
-        if "price" in data and data.get("price", {}).get("value") is None:
+        price = data.get("price")
+        if price is not None and price.get("value") is None:
             data.pop("price")
 
         if "geometry" not in data:

--- a/idunn/utils/prometheus.py
+++ b/idunn/utils/prometheus.py
@@ -1,9 +1,6 @@
 import contextlib
 import time
 
-from starlette.responses import Response
-from starlette.requests import Request
-
 from prometheus_client import Counter, Gauge, Histogram
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
@@ -12,8 +9,9 @@ from prometheus_client import (
     multiprocess,
 )
 
+from fastapi import Request, Response
+from fastapi.responses import PlainTextResponse
 from fastapi.routing import APIRoute
-from starlette.responses import PlainTextResponse
 
 
 """ The logic of the Prometheus metrics is defined in this module """

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,5 +1,5 @@
 from app import app
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from idunn.blocks.services_and_information import AccessibilityBlock
 from idunn.places import POI
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,4 @@
 from idunn.places.admin import Admin
-from idunn.places import POI
 
 
 def test_admin():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 from app import app
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 import pytest
 from .utils import override_settings
 

--- a/tests/test_api_circuit_breaker.py
+++ b/tests/test_api_circuit_breaker.py
@@ -3,7 +3,7 @@ import pytest
 import responses
 from app import app
 from time import sleep
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from idunn.blocks.wikipedia import WikipediaSession
 
 

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -1,4 +1,4 @@
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from unittest.mock import patch
 from elasticsearch.client import ClusterClient
 from elasticsearch.exceptions import ConnectionError

--- a/tests/test_api_with_wiki.py
+++ b/tests/test_api_with_wiki.py
@@ -1,7 +1,7 @@
 import pytest
 import responses
 from app import app
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -1,7 +1,7 @@
 import re
 import pytest
 from unittest.mock import ANY
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 
 from app import app
 from .utils import enable_pj_source, override_settings, read_fixture

--- a/tests/test_brewery.py
+++ b/tests/test_brewery.py
@@ -1,4 +1,3 @@
-from app import app
 from idunn.blocks.services_and_information import BreweryBlock, Beer
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,12 +3,14 @@ import re
 from unittest import mock
 from redis import Redis, RedisError
 from app import app, settings
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from idunn.utils.redis import RedisWrapper
-from .test_wiki_ES import basket_ball_wiki_es
-from .test_rate_limiter import mock_wikipedia
 from functools import wraps
 import pytest
+
+# Required fixtures
+from .test_wiki_ES import basket_ball_wiki_es
+from .test_rate_limiter import mock_wikipedia
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,6 +1,6 @@
 from unittest.mock import ANY
 from app import app
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from freezegun import freeze_time
 
 from .utils import enable_pj_source

--- a/tests/test_closest.py
+++ b/tests/test_closest.py
@@ -1,4 +1,4 @@
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 
 from app import app
 

--- a/tests/test_covid19.py
+++ b/tests/test_covid19.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from freezegun import freeze_time
 
 from app import app

--- a/tests/test_cuisine.py
+++ b/tests/test_cuisine.py
@@ -1,4 +1,3 @@
-from app import app
 from idunn.blocks.services_and_information import CuisineBlock, Cuisine
 
 

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -3,7 +3,7 @@ import json
 import responses
 import re
 import pytest
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from app import app
 from idunn.api.directions import rate_limiter
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1,7 +1,7 @@
 import re
 import pytest
 import responses
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from unittest.mock import ANY
 

--- a/tests/test_kuzzle.py
+++ b/tests/test_kuzzle.py
@@ -1,4 +1,4 @@
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 import os
 import re
 import json

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,4 @@
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 
 from app import app
 

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -1,4 +1,4 @@
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from unittest import mock
 import json
 import os

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -1,7 +1,7 @@
 import urllib
 from unittest.mock import ANY
 from app import app
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from elasticsearch import ElasticsearchException
 

--- a/tests/test_places_by_query.py
+++ b/tests/test_places_by_query.py
@@ -1,7 +1,7 @@
 import re
 import pytest
 from app import app
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from freezegun import freeze_time
 
 from .utils import read_fixture, override_settings

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -3,7 +3,7 @@ import pytest
 import re
 from freezegun import freeze_time
 from app import app, settings
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from idunn.blocks.wikipedia import WikipediaSession
 from idunn.utils.redis import RedisWrapper
 from .utils import override_settings

--- a/tests/test_recycling.py
+++ b/tests/test_recycling.py
@@ -1,5 +1,5 @@
 from unittest.mock import ANY
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 import os
 import re
 import json

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -1,4 +1,4 @@
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from freezegun import freeze_time
 import pytest
 import os

--- a/tests/test_wiki_images.py
+++ b/tests/test_wiki_images.py
@@ -4,7 +4,7 @@ import pytest
 from app import app
 from unittest import mock
 from idunn.places import POI
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_wiki_size_limit.py
+++ b/tests/test_wiki_size_limit.py
@@ -1,4 +1,4 @@
-from starlette.testclient import TestClient
+from fastapi.testclient import TestClient
 from app import app
 import responses
 import pytest


### PR DESCRIPTION
We sticked to Fastapi 0.46 because recent versions contained bugs about recursive models.
Now that these bugs are solved, let's upgrade to the latest release !

* Fastapi 0.46 :arrow_right: 0.55
* Update `import` statemens  
  `fastapi` now re-exports the most commonly used `starlette` modules