### PR TITLE
Implement "extend_bbox" parameter on /places endpoint

### DIFF
--- a/idunn/api/constants.py
+++ b/idunn/api/constants.py
@@ -1,2 +1,9 @@
-SOURCE_OSM = "osm"
-SOURCE_PAGESJAUNES = "pages_jaunes"
+from enum import Enum
+
+
+class PoiSource(str, Enum):
+    OSM = "osm"
+    PAGESJAUNES = "pages_jaunes"
+
+
+ALL_POI_SOURCES = [s.value for s in PoiSource]

--- a/idunn/api/places_list.py
+++ b/idunn/api/places_list.py
@@ -1,6 +1,7 @@
 import os
 import logging
 
+from shapely.geometry import MultiPoint
 from fastapi import HTTPException, Query
 from fastapi.concurrency import run_in_threadpool
 
@@ -18,9 +19,9 @@ from idunn.places.event import Event
 from idunn.geocoder.bragi_client import bragi_client
 from idunn.datasources.pages_jaunes import pj_source
 from idunn.datasources.kuzzle import kuzzle_client
-from .constants import SOURCE_OSM, SOURCE_PAGESJAUNES
+from .constants import PoiSource, ALL_POI_SOURCES
 
-from pydantic import BaseModel, ValidationError, validator
+from pydantic import BaseModel, ValidationError, validator, root_validator, Field
 from typing import List, Optional, Any, Tuple
 
 
@@ -28,8 +29,7 @@ logger = logging.getLogger(__name__)
 
 MAX_WIDTH = 1.0  # max bbox longitude in degrees
 MAX_HEIGHT = 1.0  # max bbox latitude in degrees
-
-ALL_SOURCES = [SOURCE_OSM, SOURCE_PAGESJAUNES]
+EXTENDED_BBOX_MAX_SIZE = 0.8  # max bbox width and height after second extended query
 
 
 def get_categories():
@@ -96,20 +96,21 @@ class PlacesQueryParam(CommonQueryParam):
     raw_filter: Optional[List[str]]
     source: Optional[str]
     q: Optional[str]
+    extend_bbox: bool = False
 
     def __init__(self, **data: Any):
-        super().__init__(**data)
-        if not self.raw_filter and not self.category and not self.q:
+        try:
+            super().__init__(**data)
+        except ValidationError as e:
             raise HTTPException(
-                status_code=400,
-                detail="One of 'category', 'raw_filter' or 'q' parameter is required",
+                status_code=400, detail=e.errors(),
             )
 
     @validator("source", pre=True, always=True)
     def valid_source(cls, v):
         if not v:
             return None
-        if v not in ALL_SOURCES:
+        if v not in ALL_POI_SOURCES:
             raise ValueError(f"unknown source: '{v}'")
         return v
 
@@ -135,6 +136,24 @@ class PlacesQueryParam(CommonQueryParam):
             ret.append(ALL_CATEGORIES.get(x))
         return ret
 
+    @root_validator(skip_on_failure=True)
+    def categories_or_raw_filters(cls, values):
+        if values.get("raw_filter") and values.get("category"):
+            raise HTTPException(
+                status_code=400,
+                detail="Both 'raw_filter' and 'category' parameters cannot be provided together",
+            )
+        return values
+
+    @root_validator(skip_on_failure=True)
+    def any_query_present(cls, values):
+        if not any((values.get("raw_filter"), values.get("category"), values.get("q"))):
+            raise HTTPException(
+                status_code=400,
+                detail="One of 'category', 'raw_filter' or 'q' parameter is required",
+            )
+        return values
+
 
 class EventQueryParam(CommonQueryParam):
     category: Optional[str]
@@ -152,86 +171,115 @@ class EventQueryParam(CommonQueryParam):
         return v
 
 
-def get_raw_params(bbox, category, raw_filter, source, q, size, lang, verbosity):
-    raw_params = {
-        "bbox": bbox,
-        "category": category,
-        "raw_filter": raw_filter,
-        "source": source,
-        "q": q,
-        "size": size,
-        "lang": lang,
-        "verbosity": verbosity,
-    }
-    if raw_params.get("raw_filter") and raw_params.get("category"):
-        raise HTTPException(
-            status_code=400,
-            detail="Both 'raw_filter' and 'category' parameters cannot be provided together",
-        )
-    return raw_params
+class PlacesBboxResponse(BaseModel):
+    places: List[Any]
+    source: PoiSource
+    bbox: Optional[Tuple[float, float, float, float]] = Field(
+        description="Minimal bbox containing all results. `null` if no result is found. May be larger than or outside of the original bbox passed in the query if `?extend_bbox=true` was set.",
+        example=(2.32, 48.85, 2.367, 48.866),
+    )
+    bbox_extended: bool = Field(
+        description="`true` if `?extend_bbox=true` was set and search has been executed on an extended bbox, after no result was found in the original bbox passed in the query."
+    )
+
+    @validator("bbox")
+    def round_bbox_values(cls, v):
+        if v is None:
+            return v
+        return tuple(round(x, 6) for x in v)
 
 
 async def get_places_bbox(
-    bbox: Any,
+    bbox: str = Query(
+        ...,
+        title="Bounding box to search",
+        description="Format: left_lon,bottom_lat,right_lon,top_lat",
+        example="-4.56,48.35,-4.42,48.46",
+    ),
     category: Optional[List[str]] = Query(None),
     raw_filter: Optional[List[str]] = Query(None),
     source: Optional[str] = Query(None),
-    q: Optional[str] = Query(None),
+    q: Optional[str] = Query(None, title="Query", description="Full text query"),
     size: Optional[int] = Query(None),
     lang: Optional[str] = Query(None),
     verbosity: Optional[str] = Query(None),
-):
-    es = get_elasticsearch()
-    raw_params = get_raw_params(bbox, category, raw_filter, source, q, size, lang, verbosity)
-    try:
-        params = PlacesQueryParam(**raw_params)
-    except ValidationError as e:
-        logger.info(f"Validation Error: {e.json()}")
-        raise HTTPException(status_code=400, detail=e.errors())
-
+    extend_bbox: bool = Query(False),
+) -> PlacesBboxResponse:
+    params = PlacesQueryParam(**locals())
     source = params.source
     if source is None:
         if (
             params.q or (params.category and all(c.get("pj_filters") for c in params.category))
         ) and pj_source.bbox_is_covered(params.bbox):
-            source = SOURCE_PAGESJAUNES
+            params.source = PoiSource.PAGESJAUNES
         else:
-            source = SOURCE_OSM
+            params.source = PoiSource.OSM
 
-    if source == SOURCE_PAGESJAUNES:
+    places_list = await _fetch_places_list(params)
+    bbox_extended = False
+
+    if params.extend_bbox and len(places_list) == 0:
+        original_bbox = params.bbox
+        original_bbox_width = original_bbox[2] - original_bbox[0]
+        original_bbox_height = original_bbox[3] - original_bbox[1]
+        original_bbox_size = max(original_bbox_height, original_bbox_width)
+        if original_bbox_size < EXTENDED_BBOX_MAX_SIZE:
+            # Compute extended bbox and fetch results a second time
+            scale_factor = EXTENDED_BBOX_MAX_SIZE / original_bbox_size
+            bbox_center_x = (original_bbox[0] + original_bbox[2]) / 2
+            bbox_center_y = (original_bbox[1] + original_bbox[3]) / 2
+            new_left = bbox_center_x - (bbox_center_x - original_bbox[0]) * scale_factor
+            new_right = bbox_center_x + (original_bbox[2] - bbox_center_x) * scale_factor
+            new_bottom = bbox_center_y - (bbox_center_y - original_bbox[1]) * scale_factor
+            new_top = bbox_center_y + (original_bbox[3] - bbox_center_y) * scale_factor
+            params.bbox = (new_left, new_bottom, new_right, new_top)
+            bbox_extended = True
+            places_list = await _fetch_places_list(params)
+
+    if len(places_list) == 0:
+        results_bbox = None
+    else:
+        points = MultiPoint([(p.get_coord()["lon"], p.get_coord()["lat"]) for p in places_list])
+        results_bbox = list(points.bounds)
+
+    result_places = await run_in_threadpool(
+        lambda: [p.load_place(params.lang, params.verbosity) for p in places_list]
+    )
+
+    return PlacesBboxResponse(
+        places=result_places, source=params.source, bbox=results_bbox, bbox_extended=bbox_extended,
+    )
+
+
+async def _fetch_places_list(params: PlacesQueryParam):
+    if params.source == PoiSource.PAGESJAUNES:
         all_categories = [pj_category for c in params.category for pj_category in c["pj_filters"]]
-        places_list = await run_in_threadpool(
+        return await run_in_threadpool(
             pj_source.get_places_bbox, all_categories, params.bbox, size=params.size, query=params.q
         )
-    elif params.q:
+    if params.q:
         # Default source (OSM) with query
         bragi_response = await bragi_client.pois_query_in_bbox(
             query=params.q, bbox=params.bbox, lang=params.lang, limit=params.size
         )
-        places_list = [BragiPOI(f) for f in bragi_response.get("features", [])]
+        return [BragiPOI(f) for f in bragi_response.get("features", [])]
+
+    # Default source (OSM) with category or class/subclass filters
+    if params.raw_filter:
+        raw_filters = params.raw_filter
     else:
-        # Default source (OSM) with query
-        if params.raw_filter:
-            raw_filters = params.raw_filter
-        else:
-            raw_filters = [f for c in params.category for f in c["raw_filters"]]
+        raw_filters = [f for c in params.category for f in c["raw_filters"]]
 
-        bbox_places = await run_in_threadpool(
-            fetch_bbox_places,
-            es,
-            INDICES,
-            raw_filters=raw_filters,
-            bbox=params.bbox,
-            max_size=params.size,
-        )
-        places_list = [POI(p["_source"]) for p in bbox_places]
-
-    return {
-        "places": await run_in_threadpool(
-            lambda: [p.load_place(params.lang, params.verbosity) for p in places_list]
-        ),
-        "source": source,
-    }
+    es = get_elasticsearch()
+    bbox_places = await run_in_threadpool(
+        fetch_bbox_places,
+        es,
+        INDICES,
+        raw_filters=raw_filters,
+        bbox=params.bbox,
+        max_size=params.size,
+    )
+    return [POI(p["_source"]) for p in bbox_places]
 
 
 def get_events_bbox(

--- a/idunn/api/urls.py
+++ b/idunn/api/urls.py
@@ -1,7 +1,7 @@
 from .pois import get_poi
 from .places import get_place, get_place_latlon, handle_option
 from .status import get_status
-from .places_list import get_places_bbox, get_events_bbox
+from .places_list import get_places_bbox, get_events_bbox, PlacesBboxResponse
 from .categories import get_all_categories
 from .closest import closest_address
 from ..directions.models import DirectionsResponse
@@ -31,9 +31,14 @@ def get_api_urls(settings):
         APIRoute("/metrics", metric_handler, include_in_schema=False),
         APIRoute("/status", get_status, include_in_schema=False),
         # Deprecated POI route
-        APIRoute("/pois/{id}", get_poi, deprecated=True),
+        APIRoute("/pois/{id}", get_poi, deprecated=True, include_in_schema=False),
         # Places
-        APIRoute("/places", get_places_bbox),
+        APIRoute(
+            "/places",
+            get_places_bbox,
+            response_model=PlacesBboxResponse,
+            responses={400: {"description": "Client Error in query params"}},
+        ),
         APIRoute("/places/latlon:{lat}:{lon}", get_place_latlon),
         APIRoute("/places/{id}", handle_option, methods=["OPTIONS"], include_in_schema=False),
         APIRoute("/places/{id}", get_place),

--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -26,6 +26,7 @@ from idunn.blocks import (
 )
 from idunn.utils import prometheus
 from idunn.utils.index_names import INDICES
+from idunn.utils.es_wrapper import get_elasticsearch
 import phonenumbers
 
 logger = logging.getLogger(__name__)
@@ -157,7 +158,8 @@ def fetch_es_poi(id, es) -> dict:
         raise HTTPException(status_code=404, detail=e.message)
 
 
-def fetch_bbox_places(es, indices, raw_filters, bbox, max_size) -> list:
+def fetch_es_pois(raw_filters, bbox, max_size) -> list:
+    es = get_elasticsearch()
     left, bot, right, top = bbox[0], bbox[1], bbox[2], bbox[3]
 
     terms_filters = []
@@ -183,7 +185,7 @@ def fetch_bbox_places(es, indices, raw_filters, bbox, max_size) -> list:
             )
 
     bbox_places = es.search(
-        index=indices["poi"],
+        index=INDICES["poi"],
         body={
             "query": {
                 "bool": {

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from .base import BasePlace
 from .place import PlaceMeta
-from ..api.constants import SOURCE_PAGESJAUNES
+from ..api.constants import PoiSource
 
 DOCTORS = (
     "Chiropracteur",
@@ -177,7 +177,7 @@ class PjPOI(BasePlace):
         return [p.get("url", "") for p in photos]
 
     def get_meta(self):
-        return PlaceMeta(source=SOURCE_PAGESJAUNES)
+        return PlaceMeta(source=PoiSource.PAGESJAUNES)
 
     def get_raw_grades(self):
         return self.get("grades")

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -30,6 +30,8 @@ def test_bbox():
 
     assert resp == {
         "source": "osm",
+        "bbox": [2.325004, 48.858956, 2.357737, 48.866185],
+        "bbox_extended": False,
         "places": [
             {
                 "type": "poi",
@@ -417,6 +419,8 @@ def test_size_list():
 
     assert resp == {
         "source": "osm",
+        "bbox": ANY,
+        "bbox_extended": False,
         "places": [
             {
                 "type": "poi",
@@ -626,6 +630,8 @@ def test_single_raw_filter():
                 "meta": ANY,
             }
         ],
+        "bbox": ANY,
+        "bbox_extended": False,
     }
 
 
@@ -641,6 +647,26 @@ def test_raw_filter_with_class_subclass():
 
     assert len(resp["places"]) == 1
     assert resp["places"][0]["name"] == "Louvre Museum"
+
+
+def test_extend_bbox():
+    client = TestClient(app)
+    small_bbox = "2.350,48.850,2.351,48.851"
+
+    response = client.get(
+        url=f"http://localhost/v1/places?bbox={small_bbox}&raw_filter=museum,museum"
+    )
+    assert response.status_code == 200
+    assert len(response.json()["places"]) == 0
+
+    response = client.get(
+        url=f"http://localhost/v1/places?bbox={small_bbox}&raw_filter=museum,museum&extend_bbox=true"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["places"]) == 1
+    assert data["bbox_extended"] == True
+    assert data["bbox"] == [2.338028, 48.861147, 2.338028, 48.861147]
 
 
 def test_invalid_bbox():
@@ -732,6 +758,8 @@ def test_valid_category():
                 "meta": {"source": "osm"},
             }
         ],
+        "bbox": ANY,
+        "bbox_extended": False,
     }
 
 
@@ -764,6 +792,8 @@ def test_places_with_explicit_source_osm():
                 "meta": {"source": "osm"},
             }
         ],
+        "bbox": ANY,
+        "bbox_extended": False,
     }
 
 

--- a/tests/test_places_by_query.py
+++ b/tests/test_places_by_query.py
@@ -20,11 +20,6 @@ def mock_autocomplete_post(httpx_mock):
 
 @freeze_time("2020-05-14 08:30:00+02:00")
 def test_places_bbox_with_osm_query(mock_autocomplete_post):
-    """
-        Test the bbox query:
-        Query first all categories in fixtures with bbox that excludes the patisserie POI
-        We should have 5 POI results including: blancs_manteaux, orsay and louvre, but not patisserie_peron (not in bbox)
-    """
     client = TestClient(app)
 
     response = client.get(url=f"http://localhost/v1/places?bbox={BBOX}&q=carrefour&source=osm")


### PR DESCRIPTION
## Description

* `/v1/places` endpoint accepts a new boolean parameter: `extend_bbox` (false by default). If this parameter is set to true and no results are found in the original `bbox`, a second query will be executed on an extended bbox and its results will be returned instead.
* In addition to the `places` list and `source`, 2 new fields are present in the response:
  * `bbox`: The minimal bbox containing all results. `null` if no place is found.  
It may be **larger** than or **outside** of the original bbox passed in the query if `extend_bbox=true` was set.
  * `bbox_extended` (bool): true if `extend_bbox=true` was set and a second search has been executed, after no results were found in the original bbox included in the URL.

## Why
This new option should enable the front-end application to adapt the view to show relevant results on the map, without manual "zoom out" by the user.