### PR TITLE
nlu: Make tagger and classifier 'domain' configurable

### DIFF
--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -41,8 +41,10 @@ class NLU_Helper:
 
     async def post_nlu_classifier(self, text):
         classifier_url = settings["NLU_CLASSIFIER_URL"]
+        classifier_domain = settings["NLU_CLASSIFIER_DOMAIN"]
         response_classifier = await self.client.post(
-            classifier_url, json={"text": text, "domain": "poi", "language": "fr", "count": 1},
+            classifier_url,
+            json={"text": text, "domain": classifier_domain, "language": "fr", "count": 1},
         )
         response_classifier.raise_for_status()
         return response_classifier
@@ -186,8 +188,13 @@ class NLU_Helper:
 
     async def post_intentions(self, text, lang, focus=None):
         tagger_url = settings["NLU_TAGGER_URL"]
+        tagger_domain = settings["NLU_TAGGER_DOMAIN"]
         # this settings is an immutable string required as a parameter for the NLU API
-        params = {"text": text, "lang": lang or settings["DEFAULT_LANGUAGE"], "domain": "poi"}
+        params = {
+            "text": text,
+            "lang": lang or settings["DEFAULT_LANGUAGE"],
+            "domain": tagger_domain,
+        }
         response_nlu = await self.client.post(tagger_url, json=params)
         response_nlu.raise_for_status()
         return response_nlu

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -112,7 +112,9 @@ BRAGI_BASE_URL: "http://bragi:4000"
 AUTOCOMPLETE_NLU_DEFAULT: False
 NLU_ALLOWED_LANGUAGES: "en,fr"
 NLU_TAGGER_URL:
+NLU_TAGGER_DOMAIN: "poi"
 NLU_CLASSIFIER_URL:
+NLU_CLASSIFIER_DOMAIN: "poi"
 
 NLU_BREAKER_TIMEOUT: 120 # timeout period in seconds
 NLU_BREAKER_MAXFAIL: 5 # consecutive failures before breaking


### PR DESCRIPTION
## Why
`poi` is the default value for `domain`, but other instances may expose other model names.