### PR TITLE
Places list: make extended bbox size configurable, and reduce default value

### DIFF
--- a/idunn/api/places_list.py
+++ b/idunn/api/places_list.py
@@ -28,7 +28,9 @@ logger = logging.getLogger(__name__)
 
 MAX_WIDTH = 1.0  # max bbox longitude in degrees
 MAX_HEIGHT = 1.0  # max bbox latitude in degrees
-EXTENDED_BBOX_MAX_SIZE = 0.8  # max bbox width and height after second extended query
+EXTENDED_BBOX_MAX_SIZE = float(
+    settings["LIST_PLACES_EXTENDED_BBOX_MAX_SIZE"]
+)  # max bbox width and height after second extended query
 
 
 def get_categories():

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -46,7 +46,9 @@ PLACE_DEFAULT_INDEX: "munin,munin_poi_nosearch"
 
 WIKI_DESC_MAX_SIZE: 325 # max size allowed to the description of the wiki block
 
+## Places list
 LIST_PLACES_MAX_SIZE: 50
+LIST_PLACES_EXTENDED_BBOX_MAX_SIZE: "0.4" # Lat/lon degrees
 
 ########################
 ## Redis


### PR DESCRIPTION
## Description
The extent of the extended bbox was hardcoded, and may be too large for queries located in dense areas.
This PR makes this value configurable, and updates the default value from 0.8 to 0.4°.

cc @bbecquet @G-Ray 