### PR TITLE
Fix unhandled exception logger format when app is preloaded by gunicorn

### DIFF
--- a/idunn/utils/logging.py
+++ b/idunn/utils/logging.py
@@ -25,6 +25,9 @@ def get_logging_dict(settings):
             "uvicorn": {"level": "INFO", "handlers": ["console"], "propagate": False},
             "uvicorn.access": {"level": "WARNING", "handlers": ["console"], "propagate": False,},
             "gunicorn": {"level": "INFO", "handlers": ["console"], "propagate": False},
+            # "gunicorn.error" logger needs to be defined explicitly,
+            # as it will be used by UvicornWorker to configure its own error logger
+            "gunicorn.error": {"level": "INFO", "handlers": ["console"], "propagate": False},
         },
         "root": {"level": "INFO", "handlers": ["console"]},
     }


### PR DESCRIPTION
Because of some obscure interaction with gunicorn and the `UvicornWorker` we are using in the Docker image, the unhandled exceptions were not logged with the expected json formatter.

This is also due to how the `--preload` option is used with gunicorn, to load the app before all workers are initialized (and might define their own logger configuration).