### PR TITLE
add city informations in admins for PJ POIs

### DIFF
--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -146,28 +146,54 @@ class PjPOI(BasePlace):
         return self.get("WheelchairAccessible")
 
     def build_address(self, lang):
-        raw_address = self.get("Address", {})
-        city = raw_address.get("City", "")
-        number = raw_address.get("Number", "")
-        postal_code = raw_address.get("PostalCode", "")
-        street = raw_address.get("Street", "")
+        city = self.get_city()
+        postcode = self.get_postcode()
+        number = self.raw_address().get("Number", "")
+        street = self.raw_address().get("Street", "")
 
         return {
             "id": None,
             "name": f"{number} {street}".strip(),
             "housenumber": number,
-            "postcode": postal_code,
-            "label": f"{number} {street}, {postal_code} {city}".strip().strip(","),
+            "postcode": postcode,
+            "label": f"{number} {street}, {postcode} {city}".strip().strip(","),
             "admin": None,
-            "admins": [],
+            "admins": self.build_admins(),
             "street": {
                 "id": None,
                 "name": street,
                 "label": f"{street} ({city})",
-                "postcodes": [postal_code] if postal_code else [],
+                "postcodes": [postcode] if postcode else [],
             },
             "country_code": self.get_country_code(),
         }
+
+    def build_admins(self):
+        city = self.get_city()
+        postcode = self.get_postcode()
+
+        if postcode:
+            label = f"{city} ({postcode})"
+        else:
+            label = city
+
+        return [
+            {
+                "name": city,
+                "label": label,
+                "class_name": "city",
+                "postcodes": [postcode] if postcode else [],
+            }
+        ]
+
+    def raw_address(self):
+        return self.get("Address", {})
+
+    def get_city(self):
+        return self.raw_address().get("City", "")
+
+    def get_postcode(self):
+        return self.raw_address().get("PostalCode", "")
 
     def get_country_codes(self):
         return ["FR"]

--- a/tests/test_pj_poi.py
+++ b/tests/test_pj_poi.py
@@ -34,6 +34,11 @@ def test_pj_place():
         assert resp["meta"]["source"] == "pages_jaunes"
         assert resp["geometry"]["center"] == [2.362634, 48.859702]
 
+        assert resp["address"]["admins"]
+        admin = resp["address"]["admins"][0]
+        assert admin["name"] == "Paris"
+        assert admin["postcodes"] == ["75003"]
+
         blocks = resp["blocks"]
         assert blocks[0]["type"] == "opening_hours"
         assert blocks[0]["raw"] == "Tu-Su 10:30-18:00"


### PR DESCRIPTION
Fill `admins` field with city information for POI addresses from PJ.

From `<IDUNN>/v1/places?bbox=2.327,48.852,2.347,48.857&category=pharmacy` (removing most fields other than `address`):

```json
"places": [{
      "type": "poi",
      "id": "pj:01546115",
      "name": "Citypharma",
      "address": {
        "id": null,
        "name": "26 rue du Four",
        "label": "26 rue du Four, 75006 Paris",
        "housenumber": "26",
        "street": {  },
        "postcode": "75006",
        "admins": [
          {
            "id": null,
            "name": "Paris",
            "label": "Paris (75006)",
            "class_name": "city",
            "postcodes": [
              "75006"
            ]
          }
        ],
        "admin": null,
        "country_code": "FR"
      }
}]
```

The only field from [`AdministrativeRegion`](https://github.com/QwantResearch/idunn/blob/master/idunn/places/place.py#L18-L23) left empty is the `id`.