### PR TITLE
Add explicit error message on connect timeout to Bragi

### DIFF
--- a/idunn/geocoder/bragi_client.py
+++ b/idunn/geocoder/bragi_client.py
@@ -23,10 +23,14 @@ class BragiClient:
 
     async def raw_autocomplete(self, params, body=None):
         url = settings["BRAGI_BASE_URL"] + "/autocomplete"
-        if body:
-            response = await self.client.post(url, params=params, json=body)
-        else:
-            response = await self.client.get(url, params=params)
+        try:
+            if body:
+                response = await self.client.post(url, params=params, json=body)
+            else:
+                response = await self.client.get(url, params=params)
+        except httpx.ConnectTimeout:
+            logger.error("Request to Bragi %s failed with timeout", url, exc_info=True)
+            raise HTTPException(503, "Server error: geocoder timeout")
 
         if response.status_code != httpx.codes.ok:
             try:


### PR DESCRIPTION
`ConnectTimeout` errors have been noticed in some cases in our deployed environments.
These errors caused unhandled exceptions.

This PR defines an explicit error message in this case, to make the investigation easier.
