### PR TITLE
Define setting to call NLU APIs as dry run

### DIFF
--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -112,6 +112,7 @@ PUBLIC_TRANSPORTS_RESTRICT_TO_CITIES: "paris,lyon" # use an empty string to allo
 ## Geocoding
 BRAGI_BASE_URL: "http://bragi:4000"
 AUTOCOMPLETE_NLU_DEFAULT: False
+AUTOCOMPLETE_NLU_SHADOW_ENABLED: False # if True, NLU APIs are always called, even if nlu intentions are not required by the request
 NLU_ALLOWED_LANGUAGES: "en,fr"
 NLU_TAGGER_URL:
 NLU_TAGGER_DOMAIN: "poi"


### PR DESCRIPTION
When `AUTOCOMPLETE_NLU_SHADOW_ENABLED` is true, intentions are always retrieved for each /autocomplete call, independently of whether `?nlu` is set or not.

This is useful to measure the impact of these calls, before the feature is effectively used by the application.