### PR TITLE
remove unnecessary trailing commas

### DIFF
--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -65,7 +65,7 @@ BLOCKS_BY_VERBOSITY = {
         GradesBlock,
         RecyclingBlock,
     ],
-    SHORT: [OpeningHourBlock, Covid19Block,],
+    SHORT: [OpeningHourBlock, Covid19Block],
 }
 ALL_VERBOSITY_LEVELS = list(BLOCKS_BY_VERBOSITY.keys())
 

--- a/idunn/blocks/services_and_information.py
+++ b/idunn/blocks/services_and_information.py
@@ -47,7 +47,7 @@ class AccessibilityBlock(BaseBlock):
         if all(s == cls.STATUS_UNKNOWN for s in (wheelchair, toilets_wheelchair)):
             return None
 
-        return cls(wheelchair=wheelchair, toilets_wheelchair=toilets_wheelchair,)
+        return cls(wheelchair=wheelchair, toilets_wheelchair=toilets_wheelchair)
 
 
 class InternetAccessBlock(BaseBlock):
@@ -141,7 +141,7 @@ class ServicesAndInformationBlock(BaseBlock):
     BLOCK_TYPE: ClassVar = "services_and_information"
 
     blocks: List[BaseBlock] = BlocksValidator(
-        allowed_blocks=[AccessibilityBlock, InternetAccessBlock, BreweryBlock, CuisineBlock,]
+        allowed_blocks=[AccessibilityBlock, InternetAccessBlock, BreweryBlock, CuisineBlock]
     )
 
     @classmethod

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -23,7 +23,7 @@ def test_undefined_wheelchairs():
     defined there is no block 'accessibility'
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:node:738042332?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:node:738042332?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -45,7 +45,7 @@ def test_wheelchair():
     are defined
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:node:36153811?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:node:36153811?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,7 @@ from .utils import override_settings
 
 def test_basic_query():
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -26,7 +26,7 @@ def test_basic_query():
 
 def test_lang():
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=it",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=it")
 
     assert response.status_code == 200
 
@@ -49,7 +49,7 @@ def test_contact_phone():
     We test this tag is correct here
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426")
 
     assert response.status_code == 200
 
@@ -72,7 +72,7 @@ def test_block_null():
     We check the API answer is ok (status_code == 200) with the correct fields.
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:way:55984117?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:way:55984117?lang=fr")
 
     assert response.status_code == 200
 
@@ -90,7 +90,7 @@ def test_block_null():
 
 def test_unknown_poi():
     client = TestClient(app)
-    response = client.get(url="http://localhost/v1/pois/an_unknown_poi_id",)
+    response = client.get(url="http://localhost/v1/pois/an_unknown_poi_id")
 
     assert response.status_code == 404
     assert "'an_unknown_poi_id' not found" in response.json()["detail"]
@@ -103,7 +103,7 @@ def test_services_and_information():
     internet_access, brewery).
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
 
@@ -114,7 +114,7 @@ def test_services_and_information():
         {"type": "internet_access", "wifi": True},
         {
             "type": "brewery",
-            "beers": [{"name": "Tripel Karmeliet"}, {"name": "Delirium"}, {"name": "Chouffe"},],
+            "beers": [{"name": "Tripel Karmeliet"}, {"name": "Delirium"}, {"name": "Chouffe"}],
         },
     ]
 
@@ -141,7 +141,7 @@ def options_test_with_options():
 
 def test_options_requests(options_test_with_options):
     client = TestClient(app)
-    response = client.options(url=f"http://localhost/v1/places/35460343",)
+    response = client.options(url=f"http://localhost/v1/places/35460343")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -151,6 +151,6 @@ def test_options_requests(options_test_with_options):
 
 def test_options_requests_disabled():
     client = TestClient(app)
-    response = client.options(url=f"http://localhost/v1/places/35460343",)
+    response = client.options(url=f"http://localhost/v1/places/35460343")
 
     assert response.status_code == 405

--- a/tests/test_api_circuit_breaker.py
+++ b/tests/test_api_circuit_breaker.py
@@ -39,7 +39,7 @@ def test_circuit_breaker_500(breaker_test):
         calls sent).
         """
         for i in range(10):
-            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=es",)
+            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=es")
 
         assert response.status_code == 200
 
@@ -56,7 +56,7 @@ def test_circuit_breaker_500(breaker_test):
         sleep(1)
 
         for i in range(10):
-            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=es",)
+            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=es")
         assert len(rsps.calls) == 4
 
 
@@ -78,7 +78,7 @@ def test_circuit_breaker_404(breaker_test):
         remained closed since the 404 is an exclude exception
         """
         for i in range(4):
-            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=es",)
+            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=es")
 
         assert "closed" == breaker_test.current_state
         assert len(rsps.calls) == 4

--- a/tests/test_api_with_wiki.py
+++ b/tests/test_api_with_wiki.py
@@ -67,7 +67,7 @@ def test_wikipedia_another_language():
     in another language.
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
 
     assert response.status_code == 200
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -36,7 +36,7 @@ def test_wikipedia_cache(cache_test_normal, mock_wikipedia):
     """
     We make a first request for the louvre museum POI
     """
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
     resp = response.json()
     """
     One request requires 2 wikipedia API calls
@@ -50,7 +50,7 @@ def test_wikipedia_cache(cache_test_normal, mock_wikipedia):
     As a result no more Wikipedia call should be
     made
     """
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
     resp = response.json()
 
     assert len(mock_wikipedia.calls) == 2  # the same number of requests as before
@@ -73,7 +73,7 @@ def test_wikidata_cache(cache_test_normal, basket_ball_wiki_es, monkeypatch):
         """
         rsps.add("GET", re.compile(r"^https://.*\.wikipedia.org/"), status=200)
 
-        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr")
 
         assert response.status_code == 200
         resp = response.json()
@@ -116,7 +116,7 @@ def test_wikidata_cache(cache_test_normal, basket_ball_wiki_es, monkeypatch):
             in the "get_wiki_info()" method
             """
             for i in range(10):
-                response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr",)
+                response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr")
                 resp = response.json()
                 assert any(
                     b["type"] == "wikipedia" for b in resp["blocks"][2].get("blocks")
@@ -138,7 +138,7 @@ def test_wiki_cache_unavailable(cache_test_normal, mock_wikipedia):
 
     with mock.patch.object(Redis, "get", fake_get):
         client = TestClient(app)
-        response = client.get(url="http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+        response = client.get(url="http://localhost/v1/pois/osm:relation:7515426?lang=es")
         assert response.status_code == 200
         resp = response.json()
         assert len(mock_wikipedia.calls) == 0

--- a/tests/test_covid19.py
+++ b/tests/test_covid19.py
@@ -11,7 +11,7 @@ from .utils import override_settings
 def test_covid19_block():
     with override_settings({"BLOCK_COVID_ENABLED": True, "COVID19_USE_REDIS_DATASET": False}):
         client = TestClient(app)
-        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777778?lang=es",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777778?lang=es")
 
     assert response.status_code == 200
     resp = response.json()

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -21,7 +21,7 @@ def test_full(mock_external_requests):
     Exhaustive test that checks all possible blocks
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:way:7777778?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:way:7777778?lang=es")
 
     assert response.status_code == 200
 

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -19,7 +19,7 @@ def test_full_query_admin():
         Test the response format to an admin query
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/admin:osm:relation:123057?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/places/admin:osm:relation:123057?lang=fr")
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
@@ -59,7 +59,7 @@ def test_full_query_street():
         Test the response format to a street query
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/street:35460343?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/places/street:35460343?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -135,7 +135,7 @@ def test_full_query_address():
     client = TestClient(app)
     id_moulin = urllib.parse.quote_plus("addr:5.108632;48.810273")
 
-    response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -210,7 +210,7 @@ def test_full_query_poi():
         Test the response format to a POI query
     """
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -428,7 +428,7 @@ def test_admin_i18n_name():
 
 def test_type_query_street():
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/street:35460343?lang=fr&type=street",)
+    response = client.get(url=f"http://localhost/v1/places/street:35460343?lang=fr&type=street")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -443,7 +443,7 @@ def test_type_query_address():
     client = TestClient(app)
     id_moulin = urllib.parse.quote_plus("addr:5.108632;48.810273")
 
-    response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr&type=address",)
+    response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr&type=address")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -456,7 +456,7 @@ def test_type_query_address():
 
 def test_type_query_poi():
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr&type=poi",)
+    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr&type=poi")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -478,14 +478,14 @@ def test_type_unknown():
 
     id_moulin = urllib.parse.quote_plus("addr:5.108632;48.810273")
 
-    response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr&type=globibulga",)
+    response = client.get(url=f"http://localhost/v1/places/{id_moulin}?lang=fr&type=globibulga")
     assert response.status_code == 400
     assert response._content == b'{"detail":"Wrong type parameter: type=globibulga"}'
 
 
 def test_not_found_with_type():
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/street:4242?lang=fr&type=poi",)
+    response = client.get(url=f"http://localhost/v1/places/street:4242?lang=fr&type=poi")
     assert response.status_code == 404
     assert response.json() == {"detail": "place 'street:4242' not found with type=poi"}
 
@@ -557,5 +557,5 @@ from unittest.mock import patch
 def test_no_es():
     client = TestClient(app)
 
-    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr&type=poi",)
+    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr&type=poi")
     assert response.status_code == 503

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -120,12 +120,12 @@ def test_rate_limiter_with_redis(limiter_test_normal, mock_wikipedia):
     client = TestClient(app)
 
     for i in range(3):
-        response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
         resp = response.json()
         assert any(b["type"] == "wikipedia" for b in resp["blocks"][2].get("blocks"))
 
     for i in range(2):
-        response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
         resp = response.json()
         assert all(b["type"] != "wikipedia" for b in resp["blocks"][2].get("blocks"))
 
@@ -145,7 +145,7 @@ def test_rate_limiter_without_redis():
             "GET", re.compile(r"^https://.*\.wikipedia.org/"), status=200, json={"test": "test"}
         )
         for i in range(10):
-            response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+            response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
 
         assert len(rsps.calls) == 10
 
@@ -185,7 +185,7 @@ def test_rate_limiter_with_redisError(limiter_test_interruption, mock_wikipedia,
     First we make a successful call
     before "stopping" redis
     """
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
 
     assert response.status_code == 200
     resp = response.json()
@@ -211,7 +211,7 @@ def test_rate_limiter_with_redisError(limiter_test_interruption, mock_wikipedia,
         m.setattr(RateLimiter, "limit", fake_limit)
 
         client = TestClient(app)
-        response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
 
         assert response.status_code == 200
         resp = response.json()
@@ -224,7 +224,7 @@ def test_rate_limiter_with_redisError(limiter_test_interruption, mock_wikipedia,
     Now that the redis "came back", we are expecting
     a correct answer from Idunn.
     """
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
 
     assert response.status_code == 200
     resp = response.json()
@@ -250,7 +250,7 @@ def test_rate_limiter_with_redis_interruption(
     """
     client = TestClient(app)
 
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
     assert response.status_code == 200
     resp = response.json()
 
@@ -277,7 +277,7 @@ def test_rate_limiter_with_redis_interruption(
     We interrupt the Redis service and we make a new Idunn request
     """
     docker_services._docker_compose.execute("stop", "wiki_redis")
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
     assert response.status_code == 200
     """
     The wikipedia block should not be returned:
@@ -299,7 +299,7 @@ def test_rate_limiter_with_redis_interruption(
     should be returned again.
     """
     restart_wiki_redis(docker_services)
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
     assert response.status_code == 200
     resp = response.json()
 

--- a/tests/test_recycling.py
+++ b/tests/test_recycling.py
@@ -25,7 +25,7 @@ def test_recycling():
             "POST", re.compile(r"^http://recycling.test/.*"), status=200, json=recycling_response,
         )
 
-        response = client.get(url=f"http://localhost/v1/pois/osm:node:36153800",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:node:36153800")
 
         assert response.status_code == 200
 

--- a/tests/test_wiki_ES.py
+++ b/tests/test_wiki_ES.py
@@ -34,7 +34,7 @@ def test_basket_ball():
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add("GET", re.compile(r"^https://.*\.wikipedia.org/"), status=200)
 
-        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr")
 
         assert response.status_code == 200
 
@@ -53,7 +53,7 @@ def test_basket_ball():
         API
         """
         for i in range(10):
-            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr",)
+            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr")
 
         assert len(rsps.calls) == 0
 
@@ -72,7 +72,7 @@ def test_WIKI_ES_KO(wiki_client_ko):
         )
 
         for i in range(10):
-            response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr",)
+            response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr")
 
         assert len(rsps.calls) == 0
 
@@ -129,7 +129,7 @@ def test_undefined_WIKI_ES(undefine_wiki_es):
         )
 
         for i in range(10):
-            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr",)
+            response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=fr")
 
         assert len(rsps.calls) == 10
 
@@ -144,7 +144,7 @@ def test_POI_not_in_WIKI_ES():
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add("GET", re.compile(r"^https://.*\.wikipedia.org/"), status=200)
 
-        response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:way:63178753?lang=fr")
 
         assert response.status_code == 200
 
@@ -192,6 +192,6 @@ def test_no_lang_WIKI_ES():
         """
         We make a request in russian language ("ru")
         """
-        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=ru",)
+        response = client.get(url=f"http://localhost/v1/pois/osm:way:7777777?lang=ru")
 
         assert len(rsps.calls) == 1

--- a/tests/test_wiki_images.py
+++ b/tests/test_wiki_images.py
@@ -24,7 +24,7 @@ def orsay_wiki_es(wiki_client, init_indices):
 
 def test_orsay_images():
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
@@ -44,7 +44,7 @@ def test_orsay_images():
 @mock.patch.object(POI, "get_name", lambda *x: None)
 def test_image_for_unnamed_poi():
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr",)
+    response = client.get(url=f"http://localhost/v1/places/osm:way:63178753?lang=fr")
 
     assert response.status_code == 200
     assert response.headers.get("Access-Control-Allow-Origin") == "*"

--- a/tests/test_wiki_size_limit.py
+++ b/tests/test_wiki_size_limit.py
@@ -44,7 +44,7 @@ def mock_long_wikipedia_response():
 
 def test_wiki_size_limit(wiki_max_size):
     client = TestClient(app)
-    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es",)
+    response = client.get(url=f"http://localhost/v1/pois/osm:relation:7515426?lang=es")
     assert response.status_code == 200
     resp = response.json()
 


### PR DESCRIPTION
A lot of trailing commas where kept by black when it merged multi-line calls into a single line. I suppose we can remove them once and for all as it's quite ugly.