### PR TITLE
places: Set postcode to null in 'address' when data contains multiple postcodes

### DIFF
--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -112,7 +112,10 @@ class BasePlace(dict):
         postcodes = self.get_postcodes()
         if postcodes is not None:
             if isinstance(postcodes, list):
-                postcodes = ";".join(postcodes)
+                if len(postcodes) == 1:
+                    postcodes = postcodes[0]
+                else:
+                    postcodes = None
 
         id = raw_address.get("id")
         name = raw_address.get("name")

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -327,7 +327,7 @@ def test_bbox():
                     "id": "addr:2.326285;48.859635",
                     "name": "62B Rue de Lille",
                     "housenumber": "62B",
-                    "postcode": "75007;75008",
+                    "postcode": None,
                     "label": "62B Rue de Lille (Paris)",
                     "admin": None,
                     "street": {

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -46,7 +46,7 @@ def test_full(mock_external_requests):
             "label": "62B Rue de Lille (Paris)",
             "name": "62B Rue de Lille",
             "housenumber": "62B",
-            "postcode": "75007;75008",
+            "postcode": None,
             "street": {
                 "id": "street:553660044C",
                 "name": "Rue de Lille",


### PR DESCRIPTION
This is mainly relevant for streets, that may be cover multiple postcodes.  
And the current format that joins the values with `;` is not useful for the applications.