### PR TITLE
nlu: tokens tagged as "POI" were not correctly ignored

### DIFF
--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -18,7 +18,7 @@ from .bragi_client import bragi_client
 DEFAULT_BBOX_WIDTH = 0.02
 DEFAULT_BBOX_HEIGHT = 0.01
 
-NLU_POI_TAGS = ["poi", "other"]
+NLU_POI_TAGS = ["POI", "other"]
 NLU_BRAND_TAGS = ["brand"]
 NLU_CATEGORY_TAGS = ["cat"]
 NLU_PLACE_TAGS = ["city", "country", "state", "street"]

--- a/tests/fixtures/autocomplete/nlu/with_poi.json
+++ b/tests/fixtures/autocomplete/nlu/with_poi.json
@@ -1,7 +1,12 @@
 {
     "NLU": [
         {
-            "phrase": "tour eiffel",
+            "phrase": "restaurant",
+            "tag": "cat",
+            "value": {}
+        },
+        {
+            "phrase": "le grand bleu",
             "tag": "POI",
             "value": {}
         },
@@ -11,8 +16,10 @@
             "value": {}
         }
     ],
-    "domain": "poi",
+    "detok": true,
+    "domain": "MAPS",
     "lang": "fr",
-    "text": "tour eiffel paris",
-    "tokenized": "tour eiffel paris"
+    "lowercase": true,
+    "text": "restaurant le grand bleu paris",
+    "tokenized": "restaurant le grand bleu paris"
 }

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -28,7 +28,7 @@ def mock_NLU_for(httpx_mock, dataset):
     ):
         httpx_mock.post(NLU_URL, content=FIXTURE_TOKENIZER[dataset])
         httpx_mock.post(CLASSIF_URL, content=FIXTURE_CLASSIF_pharmacy)
-        yield
+        yield FIXTURE_TOKENIZER[dataset]
 
 
 @pytest.fixture
@@ -239,6 +239,6 @@ def test_autocomplete_with_nlu_poi(mock_autocomplete_get, mock_NLU_with_poi):
     client = TestClient(app)
     assert_ok_with(
         client,
-        params={"q": "pharmacie à paris", "lang": "fr", "limit": 7, "nlu": True},
+        params={"q": mock_NLU_with_poi["text"], "lang": "fr", "limit": 7, "nlu": True},
         expected_intention=[],
     )


### PR DESCRIPTION
This PR fixes a little oversight in how tokens returned by the NLU tagger are filtered.