### PR TITLE
add radius parameter for the geocoder

### DIFF
--- a/idunn/geocoder/models/params.py
+++ b/idunn/geocoder/models/params.py
@@ -26,6 +26,7 @@ class QueryParams:
     q: str = Query(..., title="query string")
     lon: Optional[confloat(ge=-180, le=180)] = Query(None, title="latitude for the focus")
     lat: Optional[confloat(ge=-90, le=90)] = Query(None, title="longitude for the focus")
+    zoom: float = 11
     lang: Optional[str] = Query(None, title="language")
     limit: PositiveInt = 10
     pt_dataset: List[str] = Query([])
@@ -59,6 +60,17 @@ class QueryParams:
             "zone_type[]": self.zone_type,
             "poi_type[]": self.poi_type,
         }
+
+        if self.lon and self.lat:
+            if self.zoom >= 11:
+                params["radius"] = 30
+            elif self.zoom >= 9:
+                params["radius"] = 100
+            elif self.zoom >= 7:
+                params["radius"] = 300
+            elif self.zoom >= 5:
+                params["radius"] = 1000
+
         return {k: v for k, v in params.items() if v is not None}
 
 

--- a/idunn/geocoder/models/params.py
+++ b/idunn/geocoder/models/params.py
@@ -75,12 +75,13 @@ class QueryParams:
             params["lon"] = self.lon
             params["lat"] = self.lat
 
-            # Tune the shape of the weight applie to the results based on the
-            # proximity, note that mimir uses a normal decay:
+            # Tune the shape of the weight applied to the results based on the
+            # proximity, note that mimir uses an exponential decay:
             # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_supported_decay_functions
-            params["focus_decay"] = FOCUS_DECAY
-            params["focus_offset_distance"] = int(radius / 7.5)
-            params["focus_decay_distance"] = int(6.5 * radius / 7.5)
+            params["proximity_decay"] = f"{FOCUS_DECAY:.2f}"
+            params["proximity_offset_distance"] = int(radius / 7.5)
+            params["proximity_decay_distance"] = int(6.5 * radius / 7.5)
+
         return {k: v for k, v in params.items() if v is not None}
 
 

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -122,7 +122,8 @@ NLU_CLASSIFIER_DOMAIN: "poi"
 NLU_BREAKER_TIMEOUT: 120 # timeout period in seconds
 NLU_BREAKER_MAXFAIL: 5 # consecutive failures before breaking
 
-FOCUS_ZOOM_TO_RADIUS: '[[11, 20], [9, 60], [7, 180], [5, 500], [3, 1500]]' # expected request radius from zoom level
+FOCUS_ZOOM_TO_RADIUS: "[[11, 150], [9, 450], [7, 1300], [5, 4500], [3, 13000]]" # expected request radius from zoom level
+FOCUS_DECAY: 0.4 # minimal penality outside of the radius
 
 #######################
 ## OpenAPI DOCS

--- a/idunn/utils/default_settings.yaml
+++ b/idunn/utils/default_settings.yaml
@@ -122,6 +122,8 @@ NLU_CLASSIFIER_DOMAIN: "poi"
 NLU_BREAKER_TIMEOUT: 120 # timeout period in seconds
 NLU_BREAKER_MAXFAIL: 5 # consecutive failures before breaking
 
+FOCUS_ZOOM_TO_RADIUS: '[[11, 20], [9, 60], [7, 180], [5, 500], [3, 1500]]' # expected request radius from zoom level
+
 #######################
 ## OpenAPI DOCS
 DOCS_ENABLED: False


### PR DESCRIPTION
Take benefits of https://github.com/CanalTP/mimirsbrunn/pull/417 to allow a larger focus mode with larger zoom levels.

The endpoint `autocomplete` takes a new optional parameter `zoom` to pass the current zoom level of the front-end, which is used to decide the typical expected distance of results. I am using [this branch](https://github.com/QwantResearch/erdapfel/pull/743) of erdapfel to test this change:

| Z = 3 | Z = 5 | Z = 7 | Z = 9 | Z = 11 |
|:----------------:|:-----:|-------|-------|-------------------------------|
| ![Screenshot_2020-08-19_15-49-50](https://user-images.githubusercontent.com/1173464/90643685-21b66600-e234-11ea-8bc8-8cceae6c2d06.png) | ![Screenshot_2020-08-19_15-50-11](https://user-images.githubusercontent.com/1173464/90643722-2aa73780-e234-11ea-9215-5d775af7ba05.png) | ![Screenshot_2020-08-19_15-50-38](https://user-images.githubusercontent.com/1173464/90643750-30048200-e234-11ea-8ac2-8dc5f9e6939f.png) | ![Screenshot_2020-08-19_15-50-58](https://user-images.githubusercontent.com/1173464/90643763-3561cc80-e234-11ea-820a-47cf1cb4529f.png) | ![Screenshot_2020-08-19_15-51-17](https://user-images.githubusercontent.com/1173464/90643788-3bf04400-e234-11ea-9a45-a5d7be35950d.png) | 

### Maybe some of the logic should be moved in erdapfel?

The correspondence between zoom level and radius parameter of the geocoder is defined in this PR, but one could argue that it should be implemented in the front end:

 - we could decide to set a shorter radius at equivalent zoom level on smaller devices
 - this doesn't really play well with [erdapfel setting its minimum zoom value for the focus](https://github.com/QwantResearch/erdapfel/blob/master/src/libs/suggest.js#L16), this is probably a behavior we want to keep in order not to affect the cache efficiency.