### PR TITLE
places: Use user language for 'admins' names and labels

### DIFF
--- a/idunn/places/base.py
+++ b/idunn/places/base.py
@@ -133,22 +133,22 @@ class BasePlace(dict):
             "label": label or street.get("label"),
             "admin": self.build_admin(lang),
             "street": street,
-            "admins": self.build_admins(),
+            "admins": self.build_admins(lang),
             "country_code": self.get_country_code(),
         }
 
     def build_admin(self, lang=None):
         return None
 
-    def build_admins(self):
+    def build_admins(self, lang=None):
         raw_admins = self.get_raw_admins()
         admins = []
         if not raw_admins is None:
             for raw_admin in raw_admins:
                 admin = {
                     "id": raw_admin.get("id"),
-                    "label": raw_admin.get("label"),
-                    "name": raw_admin.get("name"),
+                    "label": raw_admin.get("labels", {}).get(lang) or raw_admin.get("label"),
+                    "name": raw_admin.get("names", {}).get(lang) or raw_admin.get("name"),
                     "class_name": raw_admin.get("zone_type"),
                     "postcodes": raw_admin.get("zip_codes"),
                 }

--- a/idunn/places/event.py
+++ b/idunn/places/event.py
@@ -33,7 +33,7 @@ class Event(BasePlace):
             "name": self.get("placename"),
             "label": self.get("address"),
             "admin": self.build_admin(lang),
-            "admins": self.build_admins(),
+            "admins": self.build_admins(lang),
         }
 
     def get_meta(self):

--- a/idunn/places/pj_poi.py
+++ b/idunn/places/pj_poi.py
@@ -158,7 +158,7 @@ class PjPOI(BasePlace):
             "postcode": postcode,
             "label": f"{number} {street}, {postcode} {city}".strip().strip(","),
             "admin": None,
-            "admins": self.build_admins(),
+            "admins": self.build_admins(lang),
             "street": {
                 "id": None,
                 "name": street,
@@ -168,7 +168,7 @@ class PjPOI(BasePlace):
             "country_code": self.get_country_code(),
         }
 
-    def build_admins(self):
+    def build_admins(self, lang=None):
         city = self.get_city()
         postcode = self.get_postcode()
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -41,7 +41,20 @@ def test_full(mock_external_requests):
         },
         "address": {
             "admin": None,
-            "admins": ANY,
+            "admins": [
+                ANY,
+                ANY,
+                ANY,
+                ANY,
+                ANY,
+                {
+                    "id": "admin:osm:relation:2202162",
+                    "class_name": "country",
+                    "label": "Francia",
+                    "name": "Francia",
+                    "postcodes": [],
+                },
+            ],
             "id": "addr:2.326285;48.859635",
             "label": "62B Rue de Lille (Paris)",
             "name": "62B Rue de Lille",


### PR DESCRIPTION
This is a minor improvement to make the address/context formatting more user-friendly in the application.