### PR TITLE
nlu: Add new categories, and allow some categories to be classified from 'brand' queries

### DIFF
--- a/idunn/utils/categories.yml
+++ b/idunn/utils/categories.yml
@@ -106,10 +106,25 @@ categories:
         raw_filters:
             - "sports_centre,*"
         regex: "fitness|muscu|piscine"
+    station:
+        raw_filters:
+            - "railway,station"
+            - "railway,halt"
+        regex: "^gare( |$)"
     recycling:
         raw_filters:
             - "recycling,*"
-        regex: "recycl"
+        regex: "recycl|tri selectif|dechett?erie"
+        match_brand: True
+    parking:
+        raw_filters:
+            - "parking,*"
+        regex: "parking"
+    place_of_worship:
+        raw_filters:
+            - "place_of_worship,*"
+        regex: "cathedral|church|eglise|mosque|synagogue|temple"
+
 outing_types:
     concert:
         en:

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -42,11 +42,6 @@ def mock_NLU_with_brand_and_country(httpx_mock):
 
 
 @pytest.fixture
-def mock_NLU_with_brand_and_country(httpx_mock):
-    yield from mock_NLU_for(httpx_mock, "with_brand_and_country")
-
-
-@pytest.fixture
 def mock_NLU_with_cat(httpx_mock):
     yield from mock_NLU_for(httpx_mock, "with_cat")
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -826,6 +826,5 @@ def test_endpoint_categories():
     resp = response.json()
     categories = resp["categories"]
 
-    assert len(categories) == 13
     assert categories[0] == {"name": "restaurant", "raw_filters": ["restaurant,*", "fast_food,*"]}
     assert categories[1] == {"name": "hotel", "raw_filters": ["*,hotel"]}


### PR DESCRIPTION
* The NLU client skips the call to the classifier for "brand" queries. However we noticed the tagger may not make the distinction between "category" and "brand" reliably.  
As a workaround, this PR suggests to remove the `skip_classifier` mechanism, and to always call the "regex" classifier, and try to classify the brand query with a subset of the list of categories. These categories are tagged with `match_brand: True` in "categories.yml".

* `recycling` is currently the only category with `match_brand: True`

* Add 3 new categories: `station`, `parking`, and `place_of_worship`.