### PR TITLE
nlu_client: make sure returned category is valid

### DIFF
--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -139,7 +139,7 @@ class NLU_Helper:
             else:
                 return None
 
-        if category_name:
+        if category_name in ALL_CATEGORIES:
             return Intention(
                 filter={"category": category_name, "bbox": bbox},
                 description={"category": category_name, "place": place},
@@ -150,7 +150,7 @@ class NLU_Helper:
 
     async def build_intention_category(self, cat_query, lang, is_brand=False):
         category_name = await self.classify_category(cat_query, is_brand)
-        if category_name:
+        if category_name in ALL_CATEGORIES:
             return Intention(
                 filter={"category": category_name}, description={"category": category_name},
             )


### PR DESCRIPTION
Return an explicit category name provided by the classifier only if it belongs to the set of expected categories for Idunn.

With current behavior, if the classifier returns a category not referenced in Idunn, it will be likely to be ignored by Erdapfel and would result in a invalid call to `api/places` otherwise.