### PR TITLE
opening hours: Ignore public holidays in countries where opening_hours.js does not support them

### DIFF
--- a/idunn/blocks/opening_hour.py
+++ b/idunn/blocks/opening_hour.py
@@ -68,7 +68,7 @@ def parse_time_block(cls, es_poi, lang, raw):
 
     if not oh.validate():
         logger.info(
-            "Failed to parse happy_hours field, id:'%s' raw:'%s'",
+            "Failed to validate opening_hours field, id:'%s' raw:'%s'",
             es_poi.get_id(),
             raw,
             exc_info=True,

--- a/idunn/utils/data/opening_hours_wrapper.js
+++ b/idunn/utils/data/opening_hours_wrapper.js
@@ -41,7 +41,7 @@ function validate(raw, nmt_obj) {
         return true;
     }
     catch (err) {
-        return "" + err;
+        throw "" + err;
     }
 }
 

--- a/idunn/utils/opening_hours.py
+++ b/idunn/utils/opening_hours.py
@@ -1,7 +1,7 @@
 import os
 from datetime import date, datetime, time, timedelta
 
-from py_mini_racer.py_mini_racer import MiniRacer
+from py_mini_racer.py_mini_racer import MiniRacer, JSEvalException
 
 DIR = os.path.dirname(__file__)
 OPENING_HOURS_JS = os.path.join(DIR, "data/opening_hours.min.js")
@@ -46,11 +46,16 @@ class OpeningHours:
 
     def validate(self):
         """Check if an expression parses correctly"""
-        result = engine.call("validate", self.raw, self.nmt_obj)
-        if self.nmt_obj is not None and result is not True:
-            self.nmt_obj = None
-            return self.validate()
-        return result is True
+        try:
+            engine.call("validate", self.raw, self.nmt_obj)
+        except JSEvalException as exc:
+            if self.nmt_obj is not None and "no holidays" in str(exc):
+                # The OH library does not support public/school holidays in the current country
+                # Let's ignore the location-dependant holidays for the evaluation
+                self.nmt_obj = None
+                return self.validate()
+            return False
+        return True
 
     def is_24_7(self, dt):
         """Check if this is always open starting from a given date"""

--- a/idunn/utils/opening_hours.py
+++ b/idunn/utils/opening_hours.py
@@ -37,16 +37,20 @@ engine = OpeningHoursEngine()
 
 class OpeningHours:
     def __init__(self, oh, tz, country_code):
-        if country_code is not None:
-            country_code = country_code.lower()
-
         self.raw = oh
         self.tz = tz
-        self.nmt_obj = {"address": {"country_code": country_code}}
+        if country_code:
+            self.nmt_obj = {"address": {"country_code": country_code.lower()}}
+        else:
+            self.nmt_obj = None
 
     def validate(self):
         """Check if an expression parses correctly"""
-        return engine.call("validate", self.raw, self.nmt_obj) is True
+        result = engine.call("validate", self.raw, self.nmt_obj)
+        if self.nmt_obj is not None and result is not True:
+            self.nmt_obj = None
+            return self.validate()
+        return result is True
 
     def is_24_7(self, dt):
         """Check if this is always open starting from a given date"""

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -1,4 +1,3 @@
-import pytest
 from freezegun import freeze_time
 from unittest.mock import ANY
 from idunn.blocks.opening_hour import OpeningHourBlock
@@ -16,22 +15,26 @@ a raw json extracted from a POI located in Moscow city.
 """
 
 
-def get_moscow_poi(opening_hours):
+def get_oh_block(opening_hours, lat=48.0, lon=2.0, country_code="FR"):
+    return OpeningHourBlock.from_es(
+        POI(
+            {
+                "coord": {"lon": lon, "lat": lat},
+                "properties": {"opening_hours": opening_hours},
+                "administrative_regions": [{"country_codes": [country_code]}],
+            }
+        ),
+        lang="en",
+    )
+
+
+def get_moscow_oh(opening_hours):
     """
     returns an OpeningHourBlock from a fake json
     corresponding to a POI located in moscow city
     for different opening_hours formats.
     """
-    return OpeningHourBlock.from_es(
-        POI(
-            {
-                "coord": {"lon": 37.588161523500276, "lat": 55.74831406552745},
-                "properties": {"opening_hours": opening_hours},
-                "administrative_regions": [{"country_codes": ["RU"]}],
-            }
-        ),
-        lang="en",
-    )
+    return get_oh_block(opening_hours, lat=55.748, lon=37.588, country_code="RU")
 
 
 @freeze_time("2018-06-14 8:30:00", tz_offset=0)
@@ -42,7 +45,7 @@ def test_opening_hour_open():
     it opens at 10:00 every day and the local time
     is 11:30.
     """
-    oh_block = get_moscow_poi("Mo-Sa 10:00-22:00; Su 10:00-14:00, 18:00-22:00")
+    oh_block = get_moscow_oh("Mo-Sa 10:00-22:00; Su 10:00-14:00, 18:00-22:00")
 
     assert oh_block == OpeningHourBlock(
         type="opening_hours",
@@ -107,7 +110,7 @@ def test_opening_hour_close():
     The POI should already be closed since it's 21h30 UTC while
     the POI closes at 22h00 in UTC+3.
     """
-    oh_block = get_moscow_poi("Mo-Su 10:00-22:00")
+    oh_block = get_moscow_oh("Mo-Su 10:00-22:00")
 
     assert oh_block.status == "closed"
     assert oh_block.next_transition_datetime == "2018-06-15T10:00:00+03:00"
@@ -124,7 +127,7 @@ def test_opening_hour_next_year():
     The POI is open only in Jan and Feb, and we are in Jun.
     So it's closed, and it will be open the 2019/01/01.
     """
-    oh_block = get_moscow_poi("Jan-Feb 10:00-20:00")
+    oh_block = get_moscow_oh("Jan-Feb 10:00-20:00")
 
     assert dict(oh_block) == dict(
         type="opening_hours",
@@ -141,7 +144,7 @@ def test_opening_hour_next_year():
 
 @freeze_time("2018-06-14T23:00:00+03:00")
 def test_opening_hour_open_until_midnight():
-    oh_block = get_moscow_poi("Mo-Su 09:00-00:00")
+    oh_block = get_moscow_oh("Mo-Su 09:00-00:00")
     assert oh_block == dict(
         type="opening_hours",
         status="open",
@@ -158,7 +161,7 @@ def test_opening_hour_open_until_midnight():
 
 @freeze_time("2018-01-04T23:00:00+03:00")
 def test_opening_hour_open_until_2am():
-    oh_block = get_moscow_poi("Mo-Su 09:00-02:00")
+    oh_block = get_moscow_oh("Mo-Su 09:00-02:00")
     assert oh_block == dict(
         type="opening_hours",
         status="open",
@@ -175,7 +178,7 @@ def test_opening_hour_open_until_2am():
 
 @freeze_time("2018-10-26T15:00:00+03:00")
 def test_opening_hour_close_until_19pm():
-    oh_block = get_moscow_poi("Mo-Su 12:00-14:30; Mo-Su,PH 19:00-22:30")
+    oh_block = get_moscow_oh("Mo-Su 12:00-14:30; Mo-Su,PH 19:00-22:30")
     assert oh_block == dict(
         type="opening_hours",
         status="closed",
@@ -195,7 +198,7 @@ def test_opening_hour_days_cycle():
     Opening_hours values where a day range ends with Monday,
     to test if the "cycle" is parsed correctly.
     """
-    oh_block = get_moscow_poi("We-Mo 11:00-19:00")
+    oh_block = get_moscow_oh("We-Mo 11:00-19:00")
     assert oh_block == OpeningHourBlock(
         **dict(
             type="opening_hours",
@@ -257,7 +260,7 @@ def test_opening_hour_sunrise_sunset():
     """
     Opening_hours sunrise-sunset.
     """
-    oh_block = get_moscow_poi("sunrise-sunset")
+    oh_block = get_moscow_oh("sunrise-sunset")
 
     assert oh_block == OpeningHourBlock(
         **dict(
@@ -320,7 +323,7 @@ def test_opening_hour_24_7():
     """
     Opening_hours 24/7.
     """
-    oh_block = get_moscow_poi("24/7")
+    oh_block = get_moscow_oh("24/7")
     assert oh_block == OpeningHourBlock(
         **dict(
             type="opening_hours",
@@ -382,7 +385,7 @@ def test_opening_hour_2_years():
     """
     Opening_hours span over 2 years without explicit years.
     """
-    oh_block = get_moscow_poi("Oct-Mar 07:30-19:30; Apr-Sep 07:00-21:00")
+    oh_block = get_moscow_oh("Oct-Mar 07:30-19:30; Apr-Sep 07:00-21:00")
     assert oh_block == dict(
         type="opening_hours",
         status="open",
@@ -396,14 +399,14 @@ def test_opening_hour_2_years():
 
 @freeze_time("2019-07-01T08:00:00")
 def test_oh_with_only_closed_rules():
-    oh_block = get_moscow_poi("Apr 1-Sep 30: off")
+    oh_block = get_moscow_oh("Apr 1-Sep 30: off")
     assert oh_block is None
 
 
 @freeze_time("2019-07-01T08:00:00")
 def test_unsupported_for_pylib():
     """Expression was previously not parsed by the python library"""
-    oh_block = get_moscow_poi(
+    oh_block = get_moscow_oh(
         "Nov 3-Apr 30: 08:00-17:00; May 2-Nov 2: 08:00-17:30;"
         "Jul 14 off; May 1 off; PH 12:30-13:30 off"
     )
@@ -463,13 +466,13 @@ def test_unsupported_for_pylib():
 
 @freeze_time("2019-07-01T08:00:00")
 def test_oh_all_rules_in_the_past():
-    oh_block = get_moscow_poi("2018 Jul 02- 2018 Sep 02 Mo-Su 08:00-20:00")
+    oh_block = get_moscow_oh("2018 Jul 02- 2018 Sep 02 Mo-Su 08:00-20:00")
     assert oh_block is None
 
 
 @freeze_time("2020-07-21T08:00:00")
 def test_oh_additional_rule_overlap():
-    oh_block = get_moscow_poi("Mo-Su 18:00-22:00, Mo-Fr 11:00-14:00")
+    oh_block = get_moscow_oh("Mo-Su 18:00-22:00, Mo-Fr 11:00-14:00")
     assert oh_block == {
         "type": "opening_hours",
         "status": "open",
@@ -541,5 +544,27 @@ def test_oh_additional_rule_overlap():
 
 @freeze_time("2019-07-01T08:00:00")
 def test_oh_bad_format():
-    oh_block = get_moscow_poi("all day long")
+    oh_block = get_moscow_oh("all day long")
     assert oh_block is None
+
+
+@freeze_time("2020-09-23T16:00:00+09:00")
+def test_opening_hours_unknown_public_holidays():
+    """
+    'PH' clause should be ignored if the implementation
+     does not support public holidays in the current country
+    """
+    oh_in_tokyo = get_oh_block(
+        "We-Su 17:00-21:00; PH off", lat=35.69, lon=139.75, country_code="JP"
+    )
+    assert oh_in_tokyo == dict(
+        type="opening_hours",
+        status="closed",
+        next_transition_datetime="2020-09-23T17:00:00+09:00",
+        seconds_before_next_transition=3600,
+        is_24_7=False,
+        raw="We-Su 17:00-21:00; PH off",
+        days=ANY,
+    )
+    assert len(oh_in_tokyo.days) == 7
+    assert sum(1 if d.status == "open" else 0 for d in oh_in_tokyo.days) == 5


### PR DESCRIPTION
"opening_hours.js" support public holidays in a certain list of countries: https://github.com/opening-hours/opening_hours.js#holidays

Opening hours evaluation should ignore PH clauses in the other countries, to return opening hours for a typical week.