### PR TITLE
nlu_client: log decisions to skip NLU

### DIFF
--- a/idunn/api/geocoder.py
+++ b/idunn/api/geocoder.py
@@ -34,6 +34,12 @@ def post_filter_intention(intention, bragi_response, limit):
             matches += 1
             if matches > expected_matches:
                 return True
+
+    logging.info(
+        "Ignored intention which doesn't match enough geocoding results `%s`",
+        intention.description.query,
+        extra={"intention": intention, "bragi_response": bragi_response, "limit": limit},
+    )
     return False
 
 
@@ -54,7 +60,7 @@ async def get_autocomplete(
         try:
             return await nlu_client.get_intentions(text=query.q, lang=query.lang, focus=focus)
         except NluClientException as exp:
-            logger.warning("Ignored NLU for '%s': %s", query.q, exp.reason, extra=exp.extra)
+            logger.info("Ignored NLU for '%s': %s", query.q, exp.reason(), extra=exp.extra)
             return []
 
     autocomplete_response, intentions = await asyncio.gather(

--- a/idunn/api/geocoder.py
+++ b/idunn/api/geocoder.py
@@ -25,8 +25,8 @@ def post_filter_intention(intention, bragi_response, limit):
     # results among geocoded features seem to be too rare.
     expected_matches = limit / 2
     matches = 0
-    for f in bragi_response["features"]:
-        geocoding = f.get("properties", {}).get("geocoding", {})
+    geocodings = [f.get("properties", {}).get("geocoding", {}) for f in bragi_response["features"]]
+    for geocoding in geocodings:
         if geocoding.get("type") != "poi":
             continue
         name = geocoding.get("name", "")
@@ -38,7 +38,14 @@ def post_filter_intention(intention, bragi_response, limit):
     logging.info(
         "Ignored intention which doesn't match enough geocoding results `%s`",
         intention.description.query,
-        extra={"intention": intention, "bragi_response": bragi_response, "limit": limit},
+        extra={
+            "intention": intention.dict(),
+            "bragi_response": [
+                {"id": geocoding.get("id"), "label": geocoding.get("label")}
+                for geocoding in geocodings
+            ],
+            "limit": limit,
+        },
     )
     return False
 

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -26,9 +26,11 @@ NLU_PLACE_TAGS = ["city", "country", "state", "street"]
 
 class NluClientException(Exception):
     def __init__(self, reason):
-        self.reason = reason
-        self.extra = {}
-        super().__init__(f"No result from NLU client, reason: `{self.reason}`")
+        self.extra = {"reason": reason}
+        super().__init__(f"No result from NLU client, reason: `{self.reason()}`")
+
+    def reason(self):
+        return self.extra["reason"]
 
 
 tagger_circuit_breaker = IdunnCircuitBreaker(

--- a/idunn/geocoder/nlu_client.py
+++ b/idunn/geocoder/nlu_client.py
@@ -298,7 +298,7 @@ class NLU_Helper:
             logger.info("Detected intentions for '%s'", text, extra=logs_extra)
             return [intention]
         except NluClientException as exp:
-            exp.extra = logs_extra
+            exp.extra.update(logs_extra)
             raise exp
 
 


### PR DESCRIPTION
Add some detail on the reason why a request to the nlu client is aborted. 

This is a simple implementation that will just raise an exception holding a human-readable explanation.