### PR TITLE
Clean up error handling on /places/<id> and place_from_id

### DIFF
--- a/idunn/api/directions.py
+++ b/idunn/api/directions.py
@@ -1,7 +1,8 @@
 from fastapi import HTTPException, Query, Depends, Request, Response
 
 from idunn import settings
-from idunn.places import Latlon, place_from_id, InvalidPlaceId
+from idunn.places import Latlon, place_from_id
+from idunn.places.exceptions import IdunnPlaceError
 from idunn.utils.rate_limiter import IdunnRateLimiter
 from ..directions.client import directions_client
 
@@ -55,9 +56,9 @@ def get_directions(
 ):
     rate_limiter.check_limit_per_client(request)
     try:
-        from_place = place_from_id(origin)
-        to_place = place_from_id(destination)
-    except InvalidPlaceId as exc:
+        from_place = place_from_id(origin, follow_redirect=True)
+        to_place = place_from_id(destination, follow_redirect=True)
+    except IdunnPlaceError as exc:
         raise HTTPException(status_code=404, detail=exc.message)
 
     return directions_client.get_directions(

--- a/idunn/api/instant_answer.py
+++ b/idunn/api/instant_answer.py
@@ -48,7 +48,7 @@ class InstantAnswerResponse(BaseModel):
 
 def get_instant_answer_single_place(place_id: str, lang: str):
     try:
-        place = place_from_id(place_id)
+        place = place_from_id(place_id, follow_redirect=True)
     except:
         logger.warning("Failed to get place for instant answer", exc_info=True)
         raise HTTPException(status_code=404)

--- a/idunn/api/places.py
+++ b/idunn/api/places.py
@@ -10,6 +10,7 @@ from idunn.utils.es_wrapper import get_elasticsearch
 from idunn.utils.covid19_dataset import covid19_osm_task
 from idunn.places import Place, Latlon, place_from_id
 from idunn.places.base import BasePlace
+from idunn.places.exceptions import PlaceNotFound
 from idunn.api.utils import DEFAULT_VERBOSITY, ALL_VERBOSITY_LEVELS
 from idunn.places.exceptions import RedirectToPlaceId, InvalidPlaceId
 from .closest import get_closest_place
@@ -87,6 +88,8 @@ def get_place(
     try:
         place = place_from_id(id, type)
     except InvalidPlaceId as e:
+        raise HTTPException(status_code=404, detail=e.message)
+    except PlaceNotFound as e:
         raise HTTPException(status_code=404, detail=e.message)
     except RedirectToPlaceId as e:
         path_prefix = request.headers.get("x-forwarded-prefix", "").rstrip("/")

--- a/idunn/api/utils.py
+++ b/idunn/api/utils.py
@@ -27,6 +27,7 @@ from idunn.blocks import (
 from idunn.utils import prometheus
 from idunn.utils.index_names import INDICES
 from idunn.utils.es_wrapper import get_elasticsearch
+from idunn.places.exceptions import PlaceNotFound
 
 logger = logging.getLogger(__name__)
 
@@ -74,11 +75,6 @@ PLACE_ADDRESS_INDEX = settings["PLACE_ADDRESS_INDEX"]
 PLACE_STREET_INDEX = settings["PLACE_STREET_INDEX"]
 
 ANY = "*"
-
-
-class PlaceNotFound(Exception):
-    def __init__(self, message: str):
-        self.message = message
 
 
 class WikidataConnector:

--- a/idunn/places/__init__.py
+++ b/idunn/places/__init__.py
@@ -7,4 +7,4 @@ from .pj_poi import PjApiPOI, PjPOI
 from .latlon import Latlon
 from .event import Event
 
-from .utils import place_from_id, InvalidPlaceId
+from .utils import place_from_id

--- a/idunn/places/exceptions.py
+++ b/idunn/places/exceptions.py
@@ -1,10 +1,22 @@
-class InvalidPlaceId(ValueError):
+class IdunnPlaceError(Exception):
+    message = "Idunn place error"
+
+
+class InvalidPlaceId(IdunnPlaceError):
     def __init__(self, place_id):
         self.id = place_id
         self.message = f"Invalid place id: '{place_id}'"
-        super().__init__(self.message)
 
 
-class RedirectToPlaceId(Exception):
+class RedirectToPlaceId(IdunnPlaceError):
     def __init__(self, target_id):
         self.target_id = target_id
+        self.message = f"Place redirected to '{target_id}'"
+
+
+class PlaceNotFound(IdunnPlaceError):
+    message = "Place not found"
+
+    def __init__(self, message=None):
+        if message:
+            self.message = message


### PR DESCRIPTION
Several different exceptions have been defined to handle these errors, but they were difficult to catch properly.
This PR suggests to derive all these errors from a new `IdunnPlaceError`, and fixes some oversights:

* Unknown id for `ApiPjSource` will now raise `PlaceNotFound`. 
As a consequence `/v1/places/<id>` will return a status 404 instead of 500 in this case.

* `/v1/directions` will accept redirected place ids as `origin` or `destination`
(e.g. unknown `addr:` are redirected to their equivalent `latlon:`) 

